### PR TITLE
Show an error message when the mongo shell version is old

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -5,12 +5,6 @@
  *
  */
 
-setVerboseShell(true);
-setIndexParanoia(true);
-setAutoMulti(true);
-
-__indent = "  "
-
 __ansi = {
     csi: String.fromCharCode(0x1B) + '[',
     reset: '0',
@@ -28,6 +22,17 @@ __ansi = {
         cyan: '6'  
     }
 }
+
+var ver = db.version().split(".");
+if ( ver[0] <= parseInt("2") && ver[1] < parseInt("2") ) {
+  print(colorize("\nSorry! Mongo Shell version 2.2.x and above is required! Please upgrade.\n", "red", true));
+} 
+
+setVerboseShell(false);
+setIndexParanoia(true);
+setAutoMulti(true);
+
+__indent = "  "
 
 function setIndexParanoia( value ) { 
     if( value == undefined ) value = true; 


### PR DESCRIPTION
A small 2 line hack to display a red coloured error message when the mongo shell version is old. 

After displaying the error, I couldn't figure out how to exit from the shell. So the script will continue to execute and give the earlier error as well.

Hope this helps!
