### PR TITLE
Show a warning when using Windows

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -27,6 +27,10 @@ __ansi = {
     }
 }
 
+if (_isWindows()) {
+  print("\nSorry! MongoDB Shell Enhancements for Hackers isn't compatible with Windows.\n");
+}
+
 var ver = db.version().split(".");
 if ( ver[0] <= parseInt("2") && ver[1] < parseInt("2") ) {
   print(colorize("\nSorry! Mongo Shell version 2.2.x and above is required! Please upgrade.\n", "red", true));


### PR DESCRIPTION
I have run mongo-hacker on Windows, but results sets are illegible:

```
{  [33m"_id" [m: ObjectId( [32;4m"4f7548896187b92998000000" [m),  [33m"msg" [m:
 [32;1m"Hi" [m,  [33m"ts" [m: ISODate( [36m"20120330T05:45:45.859Z" [m) }
{  [33m"_id" [m: ObjectId( [32;4m"4f7548916187b92998000001" [m),  [33m"msg" [m:
 [32;1m"Hello" [m,  [33m"ts" [m: ISODate( [36m"20120330T05:45:53.689Z" [m) }
{  [33m"_id" [m: ObjectId( [32;4m"4f7548a66187b92998000002" [m),  [33m"msg" [m:
 [32;1m"One" [m,  [33m"ts" [m: ISODate( [36m"20120330T05:46:14.671Z" [m) }
{  [33m"_id" [m: ObjectId( [32;4m"4f7548c46187b92998000003" [m),  [33m"msg" [m:
 [32;1m"Two" [m,  [33m"ts" [m: ISODate( [36m"20120330T05:46:44.423Z" [m) }
{  [33m"_id" [m: ObjectId( [32;4m"4f7548cf6187b92998000004" [m),  [33m"msg" [m:
 [32;1m"Try again" [m,  [33m"ts" [m: ISODate( [36m"20120330T05:46:55.364Z"
[m) }
```
