### PR TITLE
Added NumberLong support

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -126,6 +126,10 @@ Date.prototype.tojson_c = function() {
     return 'ISODate(' + date + ')';
 }
 
+NumberLong.prototype.tojson_c = function(indent , nolint) {
+    return colorize(this.toNumber().toString()+"L", "red");
+}
+
 Array.tojson_c = function( a , indent , nolint ){
     var lineEnding = nolint ? " " : "\n";
 


### PR DESCRIPTION
In current version I get `x.tojson_c is not a function`, when trying to run `find()` against a collection of records, which contain fields of type NumberLong. This commit adds NumberLong support:  NumberLong(<n>) is now printed as red '<n>L'.
