### PR TITLE
avoid failure in case shell is started with --nodb option.

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -31,7 +31,7 @@ if (_isWindows()) {
   print("\nSorry! MongoDB Shell Enhancements for Hackers isn't compatible with Windows.\n");
 }
 
-if(db){ // skip check optimistically, if the shell was started with --nodb
+if(typeof db != 'undefined'){ // skip check optimistically, if the shell was started with --nodb
     var ver = db.version().split(".");
     if ( ver[0] <= parseInt("2") && ver[1] < parseInt("2") ) {
       print(colorize("\nSorry! Mongo version 2.2.x and above is required! Please upgrade.\n", "red", true));


### PR DESCRIPTION
prevents the "ReferenceError: db is not defined"
