### PR TITLE
Update README with modularisation recommendation & make syntax highlighting configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,25 @@
 
 ## Installation
 
-Link mongo_hacker.js to `.mongorc.js` in your home directory:
+Create a `.mongorc.js` folder in your home directory and link 
+mongo_hacker.js to `~/mongorc.js/init.js`:
 
 ```sh
-ln -sf <mongo-hacker-dir>/mongo_hacker.js ~/.mongorc.js
+mkdir ~/.mongorc.js/
+ln -sf <mongo-hacker-dir>/mongo_hacker.js ~/.mongorc.js/init.js
 ```
 
 Note: This currently only works with the v2.2+ of shell (which you can use with earlier versions of the server safely)
+
+## Configuring mongo_hacker.js
+
+To configure mongo_hacker.js copy the config.js template to ~/.mongorc.js/config.js and tweak the variables.
+
+
+## Add your own functions
+
+To extend mongo_hacker.js with your own enhancements, simply create ~/.mongorc.js/my.js
+and add your own functions there
 
 ## Enhancements
 
@@ -103,3 +115,5 @@ Colorized query output
 - Boolean: Blue
 - Date: Cyan
 
+
+###

--- a/config.js
+++ b/config.js
@@ -1,0 +1,17 @@
+VERBOSE_SHELL = true;
+
+/* Always show information about index use */
+INDEX_PARANOIA = true;
+/* We all have our own indention styles.. */
+INDENT = "  ";
+
+/* Syntax highlight json objects */
+/* Valid color names are: red, green, yellow, blue, magenta, cyan */
+COLOR_NUMBERS = "blue";
+COLOR_NULL    = "red";
+COLOR_UNDEFINED = "magenta";
+COLOR_OBJECTID  = "green";
+COLOR_STRING    = "green";
+COLOR_BOOLEAN   = "blue";
+COLOR_FUNCTION  = "magenta";
+

--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -41,16 +41,130 @@ try {
     print(colorize("\nSorry! Can't load everything propertly as we don't have a db yet.\n", "red", true));
 }
 
-setVerboseShell(true);
-setIndexParanoia(true);
 
-__indent = "  ";
+try {
+    setVerboseShell(VERBOSE_SHELL);
+} catch(err) {
+    setVerboseShell(true);
+}
+try {
+    setIndexParanoia(INDEX_PARANOIA);
+} catch(err) {
+    setIndexParanoia(true);
+}
+try {
+    setIndent(INDENT);
+} catch(err) {
+    setIndent("    ");
+}
+try {
+    setNumberColor(COLOR_NUMBERS);
+} catch(err) {
+    setNumberColor("blue");
+}
+try {
+    setNullColor(COLOR_NULL);
+} catch(err) {
+    setNullColor("red");
+}
+try {
+    setUndefinedColor(COLOR_UNDEFINED);
+} catch(err) {
+    setUndefinedColor("magenta");
+}
+
+try {
+    setObjectIdColor(COLOR_OBJECTID);
+} catch(err) {
+    setObjectIdColor("green");
+}
+
+try {
+    setStringColor(COLOR_STRING);
+} catch(err) {
+    setStringColor("green");
+}
+
+try {
+    setBooleanColor(COLOR_BOOLEAN);
+} catch(err) {
+    setBooleanColor("blue");
+}
+
+try {
+    setFunctionColor(COLOR_FUNCTION);
+} catch(err) {
+    setFunctionColor("magenta");
+}
 
 function setIndexParanoia( value ) {
     if( value === undefined ) value = true;
     _indexParanoia = value;
 }
 
+function setIndent( value ) {
+    __indent = value;
+}
+function setNumberColor( value ) {
+    __c_number = _validateColor(value);
+}
+function getNumberColor() {
+    return __c_number;
+}
+function setNullColor( value ) {
+    __c_null = _validateColor(value);
+}
+function getNullColor() {
+    return __c_null;
+}
+function setUndefinedColor( value ) {
+    __c_undefined = _validateColor(value);
+}
+function getUndefinedColor() {
+    return __c_undefined;
+}
+function setObjectIdColor( value ) {
+    __c_objectid = _validateColor(value);
+}
+function getObjectIdColor() {
+    return __c_objectid;
+}
+function setStringColor( value ) {
+    __c_string = _validateColor(value);
+}
+function getStringColor() {
+    return __c_string;
+}
+function setBooleanColor( value ) {
+    __c_boolean = _validateColor(value);
+}
+function getBooleanColor() {
+    return __c_boolean;
+}
+function setFunctionColor( value ) {
+    __c_function = _validateColor( value );
+}
+function getFunctionColor() {
+    return __c_function;
+}
+function _validateColor( value ) {
+    switch( value ) {
+        case "red":
+        case "green":
+        case "yellow":
+        case "blue":
+        case "magenta":
+        case "cyan":
+            break;
+        default:
+            throw "Unknown color: " + value;
+    }
+    return value;
+}
+
+function getNumberColor() {
+    return __c_number;
+}
 function controlCode( parameters ) {
     if ( parameters === undefined ) {
         parameters = "";
@@ -307,22 +421,22 @@ Array.tojson = function( a , indent , nolint ){
 };
 
 NumberLong.prototype.tojson = function() {
-    return 'NumberLong(' + colorize('"' + this.toString().match(/-?\d+/)[0] + '"', "red") + ')';
+    return 'NumberLong(' + colorize('"' + this.toString().match(/-?\d+/)[0] + '"', getNumberColor()) + ')';
 };
 
 NumberInt.prototype.tojson = function() {
-    return 'NumberInt(' + colorize('"' + this.toString().match(/-?\d+/)[0] + '"', "red") + ')';
+    return 'NumberInt(' + colorize('"' + this.toString().match(/-?\d+/)[0] + '"', getNumberColor()) + ')';
 };
 
 tojson = function( x, indent , nolint ) {
     if ( x === null )
-        return colorize("null", "red", true);
+        return colorize("null", getNullColor(), true);
 
     if ( x === undefined )
-        return colorize("undefined", "magenta", true);
+        return colorize("undefined", getUndefinedColor(), true);
 
     if ( x.isObjectId ) {
-        return 'ObjectId(' + colorize('"' + x.str + '"', "green", false, true) + ')';
+        return 'ObjectId(' + colorize('"' + x.str + '"', getObjectIdColor(), false, true) + ')';
     }
 
     if (!indent)
@@ -353,12 +467,12 @@ tojson = function( x, indent , nolint ) {
             }
         }
         s += "\"";
-        return colorize(s, "green", true);
+        return colorize(s, getStringColor(), true);
     }
     case "number":
-        return colorize(x, "red");
+        return colorize(x, getNumberColor());
     case "boolean":
-        return colorize("" + x, "blue");
+        return colorize("" + x, getBooleanColor());
     case "object": {
         s = tojsonObject( x, indent , nolint );
         if ( ( nolint === null || nolint === true ) && s.length < 80 && ( indent === null || indent.length === 0 ) ){
@@ -367,7 +481,7 @@ tojson = function( x, indent , nolint ) {
         return s;
     }
     case "function":
-        return colorize(x.toString(), "magenta");
+        return colorize(x.toString(), getFunctionColor());
     default:
         throw "tojson can't handle type " + ( typeof x );
     }

--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -31,9 +31,14 @@ if (_isWindows()) {
     print("\nSorry! MongoDB Shell Enhancements for Hackers isn't compatible with Windows.\n");
 }
 
-var ver = db.version().split(".");
-if ( ver[0] <= parseInt("2", 10) && ver[1] < parseInt("2", 10) ) {
-    print(colorize("\nSorry! Mongo version 2.2.x and above is required! Please upgrade.\n", "red", true));
+try {
+    var ver = db.version().split(".");
+    if ( ver[0] <= parseInt("2", 10) && ver[1] < parseInt("2", 10) ) {
+        print(colorize("\nSorry! Mongo version 2.2.x and above is required! Please upgrade.\n", "red", true));
+    }
+} catch(err) {
+    /* We started the shell with --nodb, no way for us to figure out the current version.. */
+    print(colorize("\nSorry! Can't load everything propertly as we don't have a db yet.\n", "red", true));
 }
 
 setVerboseShell(true);


### PR DESCRIPTION
Recommend using a specific directory structure; 
~/.mongorc.js/
    config.js
    init.js
    my.js

The shell will read everything in the ~/.mongorc.js/ folder alphabetically so we "accidentally" achieve modularisation and can use logical filenames.

Also update the syntax highlighting to be configurable from config.js, essentially just meant as a proof-of-concept - but I guess thats what most people would want to configure anyway :P

Note: We can initialise the variables to empty at the top of "mongo_hacker.js" as that would overwrite the definitions from "config.js".. so we need to try/catch them all..
A little annoying and ugly, but couldn't think of a better way.

-- EDIT
Actually.. On second thought.. It may make sense for config.js to simply define a CONFIG json object.. And then define CONFIG_DEFAULTS in init.js and merge the two.. then there is no need for that excessive try/catch stuff...
