### PR TITLE
Fixed replica set status in prompt

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -469,7 +469,7 @@ prompt = function() {
     var host = serverstatus.host.split('.')[0];
     var process = serverstatus.process;
     var version = db.serverBuildInfo().version;
-    var repl_set = db.runCommand({"replSetGetStatus": 1}).ok !== 0;
+    var repl_set = db._adminCommand({"replSetGetStatus": 1}).ok !== 0;
     var rs_state = '';
     if(repl_set) {
         rs_state = db.isMaster().ismaster ? '[primary]' : '[secondary]';


### PR DESCRIPTION
...it was also polluting mongo log with `command denied: { replSetGetStatus: 1.0 }` messages.
