### PR TITLE
BinData and UUD support

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -40,6 +40,9 @@ setVerboseShell(true);
 setIndexParanoia(true);
 
 __indent = "  ";
+// Type of function for legacy UUID objects (BinData with subtype = 3) rendering
+// Values: "java", "c#", and "default"
+uuidType = "java";
 
 function setIndexParanoia( value ) {
     if( value === undefined ) value = true;
@@ -314,6 +317,96 @@ NumberLong.prototype.tojson = function() {
 
 NumberInt.prototype.tojson = function() {
     return 'NumberInt(' + colorize('"' + this.toString().match(/-?\d+/)[0] + '"', "red") + ')';
+};
+
+function base64ToHex(base64) {
+    var base64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+    var hexDigits = "0123456789abcdef";
+    var hex = "";
+    for (var i = 0; i < 24; ) {
+        var e1 = base64Digits.indexOf(base64[i++]);
+        var e2 = base64Digits.indexOf(base64[i++]);
+        var e3 = base64Digits.indexOf(base64[i++]);
+        var e4 = base64Digits.indexOf(base64[i++]);
+        var c1 = (e1 << 2) | (e2 >> 4);
+        var c2 = ((e2 & 15) << 4) | (e3 >> 2);
+        var c3 = ((e3 & 3) << 6) | e4;
+        hex += hexDigits[c1 >> 4];
+        hex += hexDigits[c1 & 15];
+        if (e3 != 64) {
+            hex += hexDigits[c2 >> 4];
+            hex += hexDigits[c2 & 15];
+        }
+        if (e4 != 64) {
+            hex += hexDigits[c3 >> 4];
+            hex += hexDigits[c3 & 15];
+        }
+    }
+    return hex;
+}
+
+function hexToBase64(hex) {
+    var base64Digits = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    var base64 = "";
+    var group;
+    for (var i = 0; i < 30; i += 6) {
+        group = parseInt(hex.substr(i, 6), 16);
+        base64 += base64Digits[(group >> 18) & 0x3f];
+        base64 += base64Digits[(group >> 12) & 0x3f];
+        base64 += base64Digits[(group >> 6) & 0x3f];
+        base64 += base64Digits[group & 0x3f];
+    }
+    group = parseInt(hex.substr(30, 2), 16);
+    base64 += base64Digits[(group >> 2) & 0x3f];
+    base64 += base64Digits[(group << 4) & 0x3f];
+    base64 += "==";
+    return base64;
+}
+
+var platformSpecificUuidModifications = {
+    "java": function (hex) {
+        var msb = hex.substr(0, 16);
+        var lsb = hex.substr(16, 16);
+        msb = msb.substr(14, 2) + msb.substr(12, 2) + msb.substr(10, 2) + msb.substr(8, 2)
+            + msb.substr(6, 2) + msb.substr(4, 2) + msb.substr(2, 2) + msb.substr(0, 2);
+        lsb = lsb.substr(14, 2) + lsb.substr(12, 2) + lsb.substr(10, 2) + lsb.substr(8, 2)
+            + lsb.substr(6, 2) + lsb.substr(4, 2) + lsb.substr(2, 2) + lsb.substr(0, 2);
+        return msb + lsb;
+    },
+    "c#": function (hex) {
+        return hex.substr(6, 2) + hex.substr(4, 2) + hex.substr(2, 2) + hex.substr(0, 2)
+            + hex.substr(10, 2) + hex.substr(8, 2) + hex.substr(14, 2) + hex.substr(12, 2)
+            + hex.substr(16, 16);
+    },
+    "default": function (hex) {
+        return hex;
+    }
+};
+
+function UUID(uuid, type) {
+    var hex = uuid.replace(/[{}-]/g, "");
+    var typeNum = 4;
+    if (type != undefined) {
+        typeNum = 3;
+        hex = platformSpecificUuidModifications[type](hex);
+    }
+    return new BinData(typeNum, hexToBase64(hex));
+}
+
+function uuidToString(uuid, uuidType) {
+    var hex = platformSpecificUuidModifications[uuidType](base64ToHex(uuid.base64()));
+    return hex.substr(0, 8) + '-' + hex.substr(8, 4) + '-' + hex.substr(12, 4)
+        + '-' + hex.substr(16, 4) + '-' + hex.substr(20, 12);
+}
+
+BinData.prototype.tojson = function(indent , nolint) {
+    if (this.subtype() === 3) {
+        return 'UUID(' + colorize('"' + uuidToString(this, uuidType) + '"', "cyan") + ', ' + colorize('"' + uuidType + '"', "cyan") +')'
+    } else if (this.subtype() === 4) {
+        return 'UUID(' + colorize('"' + uuidToString(this, "default") + '"', "cyan") + ')'
+    } else {
+        return 'BinData(' + colorize(this.subtype(), "red") + ', ' + colorize('"' + this.base64() + '"', "green", true) + ')';
+    }
 };
 
 tojson = function( x, indent , nolint ) {


### PR DESCRIPTION
BinData and UUD support added.

UUID encoding and decoding algorithms are implemented in 4 ways:
- Default legacy UUID (subtype = 3):
  `UUID("f2474f08-44c3-ef24-74fa-012b4d7d5ead", "default")`
- Java legacy UUID (subtype = 3):
  `UUID("f2474f08-44c3-ef24-74fa-012b4d7d5ead", "java")`
- C# legacy UUID (subtype = 3):
  `UUID("f2474f08-44c3-ef24-74fa-012b4d7d5ead", "c#")`
- New UUID (subtype = 4):

``` UUID("f2474f08-44c3-ef24-74fa-012b4d7d5ead")```
```
