### PR TITLE
getEnv() does not work in OSX 10.8.2

### DIFF
--- a/mongo_hacker.js
+++ b/mongo_hacker.js
@@ -99,7 +99,11 @@ function colorize( string, color, bright, underline ) {
 
 function runMatch(cmd, args, regexp) {
     clearRawMongoProgramOutput();
-    run(cmd, args);
+    if (args) {
+        run(cmd, args);
+    } else {
+        run(cmd);
+    }
     var output = rawMongoProgramOutput();
     return output.match(regexp);
 }


### PR DESCRIPTION
following error occured.

```
test> getEnv('HOME')
Fri Mar  8 00:47:10 shell: started program env
sh6956| env: : No such file or directory
Fri Mar  8 00:47:10 TypeError: runMatch("env", "", env_regex) has no properties
```
