### PR TITLE
fix BinData#tojson with subtype 3

### DIFF
--- a/hacks/common.js
+++ b/hacks/common.js
@@ -76,7 +76,7 @@ NumberInt.prototype.tojson = function() {
 
 BinData.prototype.tojson = function(indent , nolint) {
     if (this.subtype() === 3) {
-		return 'UUID(' + colorize('"' + uuidToString(this) + '"', "cyan") + ', ' + colorize('"' + mongo_hacker_config['uuid_type'] + '"', "cyan") + ')'
+        return 'UUID(' + colorize('"' + uuidToString(this) + '"', "cyan") + ', ' + colorize('"' + mongo_hacker_config['uuid_type'] + '"', "cyan") + ')'
     } else if (this.subtype() === 4) {
         return 'UUID(' + colorize('"' + uuidToString(this, "default") + '"', "cyan") + ')'
     } else {


### PR DESCRIPTION
This is a fix for problem with BinData UUID's of subtype 3.

You can reproduce it with the following command:

```
Sheldor(mongod-2.4.3) dev-comp-po> db.foo.findOne();
Thu May 30 13:57:46.863 JavaScript execution failed: ReferenceError: uuidType is not defined at /Users/pstadler/.mongorc.js:L390
```

It know correctly falls back to the configured `uuid_type`.
