### PR TITLE
add .ugly() method to dbquery

### DIFF
--- a/hacks/common.js
+++ b/hacks/common.js
@@ -306,3 +306,8 @@ DBQuery.prototype._checkMulti = function(){
     return false;
   }
 };
+
+DBQuery.prototype.ugly = function(){
+    this._prettyShell = false;
+    return this;
+}


### PR DESCRIPTION
disables .pretty() for just a single query.
