### PR TITLE
Added basic banner option for shell

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,9 @@ mongo_hacker_config = {
     enhance_api:    true,      // additonal api extensions
     indent:         2,         // number of spaces for indent
     uuid_type:      'default', // 'java', 'c#', 'python' or 'default'
+    banner_message: 'Shell Enhanced by MongoHacker Ver. ' //banner message to show on mongo shell load
+    version:        '0.0.3',    // current mongo-hacker version
+    show_banner:     true,      // show mongo-hacker version banner on startup
 
     // Shell Color Settings
     // [<color>, <bold>, <underline>]
@@ -16,5 +19,9 @@ mongo_hacker_config = {
         'function':   [ 'magenta', false, false ],
         'date':       [ 'blue', false, false ]
     }
+}
+
+if (mongo_hacker_config['show_banner']) {
+    print(mongo_hacker_config['banner_message'] + mongo_hacker_config['version']);
 }
 


### PR DESCRIPTION
So, I'm using mongo-hacker in a few projects now, and I've added my own custom stuff to it. But I'm deploying it using puppet, and it would be useful to add a banner message to show that mongo-hacker is being loaded, and what version was being loaded.

Probably over-engineered by putting it into the config, but wasn't sure the best practise?

@TylerBrock what do you think? :+1:
