### PR TITLE
Added warning for Mongo < 2.2

### DIFF
--- a/base.js
+++ b/base.js
@@ -13,3 +13,9 @@ if (_isWindows()) {
     print("\nSorry! MongoDB Shell Enhancements for Hackers isn't compatible with Windows.\n");
 }
 
+var current_version = parseFloat(db.serverBuildInfo().version).toFixed(2)
+
+if (current_version < 2.2) {
+    print("Sorry! MongoDB Shell Enhancements for Hackers is only compatible with Mongo 2.2+\n");
+}
+


### PR DESCRIPTION
Now warns if you're not using 2.2+ version of Mongo
