### PR TITLE
Enable database name autocomplete in "use <db>"

### DIFF
--- a/hacks/use_autocomplete_dbs.js
+++ b/hacks/use_autocomplete_dbs.js
@@ -1,0 +1,5 @@
+function listDbs(){
+  return db.adminCommand("listDatabases").databases.map(function(d){return d.name});
+}
+
+this.__proto__.constructor.autocomplete = listDbs;


### PR DESCRIPTION
In shell:

```
use myD<Tab>
```

will autocomplete to

```
use myDatabase
```

All this does is adds database names into autocompletion list.
