### PR TITLE
Fix `getEnv()` by anchoring the name of the env var

### DIFF
--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -10,7 +10,7 @@ function runMatch(cmd, args, regexp) {
 };
 
 function getEnv(env_var) {
-    var env_regex = new RegExp(env_var + '=(.*)');
+    var env_regex = new RegExp(' ' + env_var + '=(.*)');
     return runMatch('env', '', env_regex)[1];
 };
 


### PR DESCRIPTION
Hey @TylerBrock,

The minor change in this PR fixes the `getEnv()` function by anchoring the env var name when grepping through the command output;  this is especially important when there are multiple env vars with names that end with the same substring, as illustrated below:

**BEFORE:** `getEnv('BAR')` returns `blegga`, which is WRONG

``` shell
$ env -i FOOBAR=blegga BAR=qux /usr/local/bin/mongo --shell ~/.mongorc.js
...
hostname(mongod-2.4.8) test> getEnv('BAR')
Tue Dec 17 16:08:19.209 shell: started program env
sh48986| FOOBAR=blegga
sh48986| BAR=qux
blegga
hostname(mongod-2.4.8) test> _
```

**AFTER:** `getEnv('BAR')` returns `qux`, which is CORRECT

``` shell
$ env -i FOOBAR=blegga BAR=qux /usr/local/bin/mongo --shell ~/.mongorc.js
...
hostname(mongod-2.4.8) test> getEnv('BAR')
Tue Dec 17 16:09:17.095 shell: started program env
sh49206| FOOBAR=blegga
sh49206| BAR=qux
qux
hostname(mongod-2.4.8) test> _
```
