### PR TITLE
Fixes #77

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ install:
 	@echo "INSTALLATION"
 	@echo "Linking MongoHacker to .mongorc.js in your home directory:"
 
-	@$(MAKE) uninstall
-	ln -sf "$(CURDIR)/mongo_hacker.js" ~/.mongorc.js
+	ln -s "$(CURDIR)/mongo_hacker.js" ~/.mongorc.js
 
 uninstall:
 	rm -f ~/.mongorc.js


### PR DESCRIPTION
Now mongo hacker fails if ~/.mongorc.js already exists. This is
a more safe behavior for those who may accidentally override their
existing ~/.mongorc.js files without realizing.
