### PR TITLE
Overwrite existing symlink when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	@echo "INSTALLATION"
 	@echo "Linking MongoHacker to .mongorc.js in your home directory:"
 
-	ln -s "$(CURDIR)/mongo_hacker.js" ~/.mongorc.js
+	ln -fs "$(CURDIR)/mongo_hacker.js" ~/.mongorc.js
 
 uninstall:
 	rm -f ~/.mongorc.js


### PR DESCRIPTION
Makes updating mongo-hacker easier by allowing a `git pull && make` to work even when there is an existing symlink in `~/.mongorc.js`
