### PR TITLE
Make headings bigger than normal text

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -178,32 +178,32 @@ a:active {
  * Addresses font sizes within 'section' and 'article' in FF4+, Chrome, S5
  */
 h1 {
-  font-size: 2em;
+  font-size: 2.5em;
   margin: 0.67em 0;
 }
 
 h2 {
-  font-size: 1.5em;
+  font-size: 2em;
   margin: 0.83em 0;
 }
 
 h3 {
-  font-size: 1.17em;
+  font-size: 1.67em;
   margin: 1em 0;
 }
 
 h4 {
-  font-size: 1em;
+  font-size: 1.5em;
   margin: 1.33em 0;
 }
 
 h5 {
-  font-size: 0.83em;
+  font-size: 1.13em;
   margin: 1.67em 0;
 }
 
 h6 {
-  font-size: 0.75em;
+  font-size: 1.25em;
   margin: 2.33em 0;
 }
 


### PR DESCRIPTION
Otherwise, `<h4>` looks almost exactly like `<p>` - see Index Paranoia at http://tylerbrock.github.io/mongo-hacker/
