### PR TITLE
Fix bug in show collections

### DIFF
--- a/hacks/show.js
+++ b/hacks/show.js
@@ -58,7 +58,7 @@ shellHelper.show = function (what) {
           }
         });
         db.getCollectionNames().forEach(function (collectionName) {
-          var stats = db[collectionName].stats();
+          var stats = db.getCollection(collectionName).stats();
           while(collectionName.length < maxNameLength + paddingLength)
             collectionName = collectionName + " ";
           var size = (stats.size / 1024 / 1024).toFixed(3),


### PR DESCRIPTION
Under the strange circumstance where a collection is named "group", the show collections command fails when attempting to process that collection using the db["group"] syntax vs db.getCollection("group")
