### PR TITLE
Use getHostName() to determine the host name as opposed to serverstatus.host

### DIFF
--- a/hacks/prompt.js
+++ b/hacks/prompt.js
@@ -1,7 +1,7 @@
 // Improve the default prompt with hostname, process type, and version
 prompt = function() {
     var serverstatus = db.serverStatus();
-    var host = serverstatus.host.split('.')[0];
+    var host = getHostName().split('.')[0];
     var process = serverstatus.process;
     var version = db.serverBuildInfo().version;
     var repl_set = db._adminCommand({"replSetGetStatus": 1}).ok !== 0;


### PR DESCRIPTION
The docs say that db.serverStatus().host -should- be the same as getHostName() but that is not what I see locally and what it is returning for me is incorrect where getHostName() is correct.  I suspect that the former may be where the server was compiled and the latter is where it is actually running.