### PR TITLE
Remove `ls` when making mongo_hacker.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ all: mongo_hacker.js
 
 mongo_hacker.js: ${config} ${base} ${hacks}
 	cat $^ > $@
-	@ls -la ~/.mongorc.js
 
 install: mongo_hacker.js
 	@echo "INSTALLATION"


### PR DESCRIPTION
Remove unnecessary `ls` from `mongo_hacker.js` target; can cause the make to fail if there is no `~/.mongorc.js` file to list.