### PR TITLE
New "count doc(ument)s" shell helper/shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Colorized query output for console/terminal windows supporting ANSI color codes.
 
 ![Colorized Output](http://tylerbrock.github.com/mongo-hacker/screenshots/colorized_shell.png)
 
+### Additional shell commands
+
+The MongoDB shell offers various "shell commands" _(sometimes referred to as "shell helpers" as well)_ that make interactive use of the shell much more convenient than [proper, Javascript-only scripted use of the shell][interactive_versus_scripted].
+
+To make interactive use of the MongoDB shell even more convenient, `mongo-hacker` adds the following shell commands:
+
+* `count documents`/`count docs`: count the number of documents in all _(non-`system`)_ collections in the database - by [@pvdb][pvdb]
+
+[interactive_versus_scripted]: http://docs.mongodb.org/manual/tutorial/write-scripts-for-the-mongo-shell/#differences-between-interactive-and-scripted-mongo
+
+[pvdb]: https://github.com/pvdb
+
 ### API Additions
 
 #### General

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ mongo_hacker_config = {
   sort_keys:      false,            // sort the keys in documents when displayed
   uuid_type:      'default',        // 'java', 'c#', 'python' or 'default'
   banner_message: 'Mongo-Hacker ',  // banner message
-  version:        '0.0.5',          // current mongo-hacker version
+  version:        '0.0.6',          // current mongo-hacker version
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -11,7 +11,7 @@ shellHelper.count = function (what) {
     what = args[0]
     args = args.splice(1)
 
-    if (what == "documents") {
+    if (what == "documents" || what == "docs") {
         var maxNameLength = 0;
         var paddingLength = 2;
         db.getCollectionNames().forEach(function (collectionName) {

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -1,0 +1,36 @@
+function commify(number) {
+    // http://stackoverflow.com/questions/2901102
+    return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+// "count documents", a bit akin to "show collections"
+shellHelper.count = function (what) {
+    assert(typeof what == "string");
+
+    var args = what.split( /\s+/ );
+    what = args[0]
+    args = args.splice(1)
+
+    if (what == "documents") {
+        var maxNameLength = 0;
+        var paddingLength = 2;
+        db.getCollectionNames().forEach(function (collectionName) {
+          if (collectionName.length > maxNameLength) {
+            maxNameLength = collectionName.length;
+          }
+        });
+        db.getCollectionNames().forEach(function (collectionName) {
+          // exclude "system" collections from "count" operation
+          if (collectionName.startsWith('system.')) { return ; }
+          var count = db.getCollection(collectionName).count();
+          while(collectionName.length < maxNameLength + paddingLength)
+            collectionName = collectionName + " ";
+
+          print(colorize(collectionName, { color: 'green', bright: true }) + commify(count) + " document(s)")
+        });
+        return "";
+    }
+
+    throw "don't know how to count [" + what + "]";
+
+}


### PR DESCRIPTION
@TylerBrock - this pull request is basically to see if there's an appetite for my `"count documents"` shell helper / shell command, which I find myself using on a very frequent basis... the attached screenshot explains better than words can how it works, but it is akin to the `"show collections"` command, and borrows heavily from it for its implementation.

If you think this shell command is a useful addition to `mongo-hacker` then please accept the PR, or else I'm willing to refactor the code a bit first, as it can definitely be DRY-ed up quite a bit _(but I thought I'd check first to see if you're interested in it)_

Also, let me know if you have a better suggestion for the name (`"count collections"` maybe, even though that's not quite correct, or else `"count rows"` but that's probably too SQL-ish :smile:)

![mongo_hacker_count_documents](https://cloud.githubusercontent.com/assets/17322/7147748/34fb26b8-e2f5-11e4-996e-654a74753ac7.png)

PS - notice how the `"count documents"` command - on purpose - skips the `system` collections... we could have separate `"count system documents"` and `"count application documents"` commands, but again it's probably best to see if there's an appetite for this first... thanks!