### PR TITLE
Some minor JS refactorings

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ mongo_hacker_config = {
   sort_keys:      false,            // sort the keys in documents when displayed
   uuid_type:      'default',        // 'java', 'c#', 'python' or 'default'
   banner_message: 'Mongo-Hacker ',  // banner message
-  version:        '0.0.6',          // current mongo-hacker version
+  version:        '0.0.7',          // current mongo-hacker version
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -12,9 +12,7 @@ shellHelper.count = function (what) {
     args = args.splice(1)
 
     if (what == "documents" || what == "docs") {
-        var maxNameLength = db.getCollectionNames().reduce(function(maxLength, collectionName) {
-          return (collectionName.length > maxLength) ? collectionName.length : maxLength ;
-        }, 0);
+        var maxNameLength = maxLength(db.getCollectionNames());
         db.getCollectionNames().forEach(function (collectionName) {
           // exclude "system" collections from "count" operation
           if (collectionName.startsWith('system.')) { return ; }

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -12,13 +12,10 @@ shellHelper.count = function (what) {
     args = args.splice(1)
 
     if (what == "documents" || what == "docs") {
-        var maxNameLength = 0;
         var paddingLength = 2;
-        db.getCollectionNames().forEach(function (collectionName) {
-          if (collectionName.length > maxNameLength) {
-            maxNameLength = collectionName.length;
-          }
-        });
+        var maxNameLength = db.getCollectionNames().reduce(function(maxLength, collectionName) {
+          return (collectionName.length > maxLength) ? collectionName.length : maxLength ;
+        }, 0);
         db.getCollectionNames().forEach(function (collectionName) {
           // exclude "system" collections from "count" operation
           if (collectionName.startsWith('system.')) { return ; }

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -12,7 +12,6 @@ shellHelper.count = function (what) {
     args = args.splice(1)
 
     if (what == "documents" || what == "docs") {
-        var paddingLength = 2;
         var maxNameLength = db.getCollectionNames().reduce(function(maxLength, collectionName) {
           return (collectionName.length > maxLength) ? collectionName.length : maxLength ;
         }, 0);
@@ -20,10 +19,11 @@ shellHelper.count = function (what) {
           // exclude "system" collections from "count" operation
           if (collectionName.startsWith('system.')) { return ; }
           var count = db.getCollection(collectionName).count();
-          while(collectionName.length < maxNameLength + paddingLength)
-            collectionName = collectionName + " ";
 
-          print(colorize(collectionName, { color: 'green', bright: true }) + commify(count) + " document(s)")
+          print(
+            colorize(collectionName.pad(maxNameLength, true), { color: 'green', bright: true })
+            + "  " + commify(count) + " document(s)"
+          );
         });
         return "";
     }

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -30,3 +30,9 @@ function getSlowms(){
         return 100;
     }
 };
+
+function maxLength(listOfNames) {
+    return listOfNames.reduce(function(maxLength, name) {
+      return (name.length > maxLength) ? name.length : maxLength ;
+    }, 0);
+}

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -55,18 +55,18 @@ shellHelper.show = function (what) {
     }
 
     if (what == "collections" || what == "tables") {
-        var paddingLength = 2;
         var maxNameLength = db.getCollectionNames().reduce(function(maxLength, collectionName) {
           return (collectionName.length > maxLength) ? collectionName.length : maxLength ;
         }, 0);
         db.getCollectionNames().forEach(function (collectionName) {
           var stats = db.getCollection(collectionName).stats();
-          while(collectionName.length < maxNameLength + paddingLength)
-            collectionName = collectionName + " ";
           var size = (stats.size / 1024 / 1024).toFixed(3),
               storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
 
-          print(colorize(collectionName, { color: 'green', bright: true }) + size + "MB / " + storageSize + "MB")
+          print(
+            colorize(collectionName.pad(maxNameLength, true), { color: 'green', bright: true })
+            + "  " + size + "MB / " + storageSize + "MB"
+          );
         });
         return "";
     }

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -55,9 +55,7 @@ shellHelper.show = function (what) {
     }
 
     if (what == "collections" || what == "tables") {
-        var maxNameLength = db.getCollectionNames().reduce(function(maxLength, collectionName) {
-          return (collectionName.length > maxLength) ? collectionName.length : maxLength ;
-        }, 0);
+        var maxNameLength = maxLength(db.getCollectionNames());
         db.getCollectionNames().forEach(function (collectionName) {
           var stats = db.getCollection(collectionName).stats();
           var size = (stats.size / 1024 / 1024).toFixed(3),

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -55,13 +55,10 @@ shellHelper.show = function (what) {
     }
 
     if (what == "collections" || what == "tables") {
-        var maxNameLength = 0;
         var paddingLength = 2;
-        db.getCollectionNames().forEach(function (collectionName) {
-          if (collectionName.length > maxNameLength) {
-            maxNameLength = collectionName.length;
-          }
-        });
+        var maxNameLength = db.getCollectionNames().reduce(function(maxLength, collectionName) {
+          return (collectionName.length > maxLength) ? collectionName.length : maxLength ;
+        }, 0);
         db.getCollectionNames().forEach(function (collectionName) {
           var stats = db.getCollection(collectionName).stats();
           while(collectionName.length < maxNameLength + paddingLength)


### PR DESCRIPTION
Hey @TylerBrock,

This PR doesn't actually change any of the `mongo-hacker` functionality, but rather consists of some JS refactorings that allowed me to DRY up the `show collections` and `count documents` code a bit, by extracting some shared code into a function, as alluded to in #128 

The overall diff may be a bit harder to grok than the individual commits, which I've tried to keep as small as possible, to make reviewing this PR a tad easier... lemme know your thoughts!

Thanks,

@pvdb
