### PR TITLE
New API method: db.getMongo().getDatabaseNames()

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ To make interactive use of the MongoDB shell even more convenient, `mongo-hacker
 
 ### API Additions
 
+#### Scripting
+
+Get a list of database names: _(by [@pvdb][pvdb])_
+
+```js
+db.getMongo().getDatabaseNames()
+```
+
+_(note that this method is similar - functionality-wise and usage-wise - to the existing `db.getCollectionNames()` API method and allows for advanced, cross-database scripting in the MongoDB shell)_
+
 #### General
 
 Filter for a collection of documents:

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ mongo_hacker_config = {
   sort_keys:      false,            // sort the keys in documents when displayed
   uuid_type:      'default',        // 'java', 'c#', 'python' or 'default'
   banner_message: 'Mongo-Hacker ',  // banner message
-  version:        '0.0.7',          // current mongo-hacker version
+  version:        '0.0.8',          // current mongo-hacker version
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users

--- a/hacks/api.js
+++ b/hacks/api.js
@@ -54,7 +54,7 @@ Mongo.prototype.getDatabaseNames = function() {
     //
     // mongo-hacker FTW :-)
     return this.getDBs().databases.reduce(function(names, db) {
-      return names.concat(db.name);
+        return names.concat(db.name);
     }, []);
 }
 

--- a/hacks/api.js
+++ b/hacks/api.js
@@ -43,6 +43,21 @@ DB.prototype.rename = function(newName) {
     db = this.getSiblingDB(newName);
 };
 
+Mongo.prototype.getDatabaseNames = function() {
+    // this API addition gives us the following convenience function:
+    //
+    //   db.getMongo().getDatabaseNames()
+    //
+    // which is similar in use to:
+    //
+    //   db.getCollectionNames()
+    //
+    // mongo-hacker FTW :-)
+    return this.getDBs().databases.reduce(function(names, db) {
+      return names.concat(db.name);
+    }, []);
+}
+
 //----------------------------------------------------------------------------
 // API Modifications (additions and changes)
 //----------------------------------------------------------------------------

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -72,15 +72,13 @@ shellHelper.show = function (what) {
     if (what == "dbs" || what == "databases") {
         var dbs = db.getMongo().getDBs();
         var dbinfo = [];
-        var maxNameLength = 0;
+        var maxNameLength = maxLength(db.getMongo().getDatabaseNames());
         var maxGbDigits = 0;
 
         dbs.databases.forEach(function (x){
             var sizeStr = (x.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
-            var nameLength = x.name.length;
             var gbDigits = sizeStr.indexOf(".");
 
-            if( nameLength > maxNameLength) maxNameLength = nameLength;
             if( gbDigits > maxGbDigits ) maxGbDigits = gbDigits;
 
             dbinfo.push({

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -70,12 +70,11 @@ shellHelper.show = function (what) {
     }
 
     if (what == "dbs" || what == "databases") {
-        var dbs = db.getMongo().getDBs();
         var dbinfo = [];
         var maxNameLength = maxLength(db.getMongo().getDatabaseNames());
         var maxGbDigits = 0;
 
-        dbs.databases.forEach(function (x){
+        db.getMongo().getDBs().databases.forEach(function (x){
             var sizeStr = (x.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
             var gbDigits = sizeStr.indexOf(".");
 

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -83,8 +83,7 @@ shellHelper.show = function (what) {
 
             dbinfo.push({
                 name:      x.name,
-                size:      x.sizeOnDisk,
-                size_str:  sizeStr,
+                size_str:  (x.sizeOnDisk > 1) ? (sizeStr + "GB") : "(empty)",
                 name_size: nameLength,
                 gb_digits: gbDigits
             });
@@ -95,11 +94,7 @@ shellHelper.show = function (what) {
             var namePadding = maxNameLength - db.name_size;
             var sizePadding = maxGbDigits   - db.gb_digits;
             var padding = Array(namePadding + sizePadding + 3).join(" ");
-            if (db.size > 1) {
-                print(colorize(db.name, { color: 'green', bright: true }) + padding + db.size_str + "GB");
-            } else {
-                print(colorize(db.name, { color: 'green', bright: true }) + padding + "(empty)");
-            }
+            print(colorize(db.name, { color: 'green', bright: true }) + padding + db.size_str);
         });
 
         return "";

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -83,19 +83,15 @@ shellHelper.show = function (what) {
 
             dbinfo.push({
                 name:      x.name,
-                size_str:  (x.sizeOnDisk > 1) ? (sizeStr + "GB") : "(empty)",
-                name_size: nameLength,
-                gb_digits: gbDigits
+                size_str:  (x.sizeOnDisk > 1) ? (sizeStr + "GB") : "(empty)"
             });
         });
 
         dbinfo.sort(function (a,b) { a.name - b.name });
         dbinfo.forEach(function (db) {
-            var sizePadding = maxGbDigits - db.gb_digits;
-            var padding = Array(sizePadding + 3).join(" ");
             print(
               colorize(db.name.pad(maxNameLength, true), { color: 'green', bright: true })
-              + padding + db.size_str
+              + "  " + db.size_str.pad(maxGbDigits + 6) // xxx.000GB, so 6 trailing chars
             );
         });
 

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -91,10 +91,12 @@ shellHelper.show = function (what) {
 
         dbinfo.sort(function (a,b) { a.name - b.name });
         dbinfo.forEach(function (db) {
-            var namePadding = maxNameLength - db.name_size;
-            var sizePadding = maxGbDigits   - db.gb_digits;
-            var padding = Array(namePadding + sizePadding + 3).join(" ");
-            print(colorize(db.name, { color: 'green', bright: true }) + padding + db.size_str);
+            var sizePadding = maxGbDigits - db.gb_digits;
+            var padding = Array(sizePadding + 3).join(" ");
+            print(
+              colorize(db.name.pad(maxNameLength, true), { color: 'green', bright: true })
+              + padding + db.size_str
+            );
         });
 
         return "";


### PR DESCRIPTION
Hey @TylerBrock,

This PR adds a new API method to the MongoDB shell: `db.getMongo().getDatabaseNames()` which returns a list of database names, similar to how `db.getCollectionNames()` returns a list of collection names.

The rationale for introducing this new API method is that it allows for advanced cross-database scripting within a single MongoDB shell session... I plan to use it as the basis for a new `count collections` helper which will print out a list of database names followed by the number of collections in each of them.

Based on this new API method, I was then also able to refactor/simplify the implementation of the `show dbs` helper, which makes up the remaining commits in this PR _(which I've kept very small again, similar to what I did in #129, which should make reviewing the PR a bit easier)_.

Thanks, @pvdb!

![get_database_names](https://cloud.githubusercontent.com/assets/17322/7276127/a03d9d88-e8ff-11e4-9d7a-eadbd788c7ec.png)
