### PR TITLE
DRY up formatting padded/aligned columns

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,6 +22,7 @@ mongo_hacker_config = {
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users
   column_separator:  '→',           // separator used when printing padded/aligned columns
+  value_separator:   '/',           // separator used when merging padded/aligned values
 
   // Shell Color Settings
   // Colors available: red, green, yellow, blue, magenta, cyan

--- a/config.js
+++ b/config.js
@@ -21,6 +21,7 @@ mongo_hacker_config = {
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users
+  column_separator:  '→',           // separator used when printing padded/aligned columns
 
   // Shell Color Settings
   // Colors available: red, green, yellow, blue, magenta, cyan

--- a/hacks/common.js
+++ b/hacks/common.js
@@ -53,6 +53,11 @@ function surround(name, inside) {
     return [name, '(', inside, ')'].join('');
 }
 
+Number.prototype.commify = function() {
+    // http://stackoverflow.com/questions/2901102
+    return this.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};
+
 NumberLong.prototype.tojson = function() {
     var color = mongo_hacker_config.colors.number;
     var output = colorize('"' + this.toString().match(/-?\d+/)[0] + '"', color);

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -1,8 +1,3 @@
-function commify(number) {
-    // http://stackoverflow.com/questions/2901102
-    return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
-
 // "count documents", a bit akin to "show collections"
 shellHelper.count = function (what) {
     assert(typeof what == "string");
@@ -20,7 +15,7 @@ shellHelper.count = function (what) {
 
           print(
             colorize(collectionName.pad(maxNameLength, true), { color: 'green', bright: true })
-            + "  " + commify(count) + " document(s)"
+            + "  " + count.commify() + " document(s)"
           );
         });
         return "";

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -7,17 +7,15 @@ shellHelper.count = function (what) {
     args = args.splice(1)
 
     if (what == "documents" || what == "docs") {
-        var maxNameLength = maxLength(db.getCollectionNames());
-        db.getCollectionNames().forEach(function (collectionName) {
-          // exclude "system" collections from "count" operation
-          if (collectionName.startsWith('system.')) { return ; }
-          var count = db.getCollection(collectionName).count();
-
-          print(
-            colorize(collectionName.pad(maxNameLength, true), { color: 'green', bright: true })
-            + "  " + count.commify() + " document(s)"
-          );
+        collectionNames = db.getCollectionNames().filter(function (collectionName) {
+            // exclude "system" collections from "count" operation
+            return !collectionName.startsWith('system.');
         });
+        documentCounts = collectionNames.map(function (collectionName) {
+            var count = db.getCollection(collectionName).count();
+            return (count.commify() + " document(s)");
+        });
+        printPaddedColumns(collectionNames, documentCounts);
         return "";
     }
 

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -37,6 +37,27 @@ function maxLength(listOfNames) {
     }, 0);
 };
 
+function mergePaddedValues(leftHandValues, rightHandValues) {
+    assert(leftHandValues.length == rightHandValues.length);
+
+    maxLeftHandValueLength = maxLength(leftHandValues);
+    maxRightHandValueLength = maxLength(rightHandValues);
+
+    valueSeparator = mongo_hacker_config['value_separator'];
+
+    var combinedValues = []
+
+    for (i = 0; i < leftHandValues.length; i++) {
+        combinedValues[i] = (
+            leftHandValues[i].pad(maxLeftHandValueLength)
+            + " " + valueSeparator + " "
+            + rightHandValues[i].pad(maxRightHandValueLength)
+        );
+    }
+
+    return combinedValues;
+}
+
 function printPaddedColumns(keys, values) {
     assert(keys.length == values.length);
 

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -35,4 +35,19 @@ function maxLength(listOfNames) {
     return listOfNames.reduce(function(maxLength, name) {
       return (name.length > maxLength) ? name.length : maxLength ;
     }, 0);
-}
+};
+
+function printPaddedColumns(keys, values) {
+    assert(keys.length == values.length);
+
+    maxKeyLength   = maxLength(keys);
+    maxValueLength = maxLength(values);
+
+    for (i = 0; i < keys.length; i++) {
+        print(
+            colorize(keys[i].pad(maxKeyLength, true), { color: 'green', bright: true })
+            + " - " // column separator...
+            + values[i].pad(maxValueLength)
+        );
+    }
+};

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -43,10 +43,12 @@ function printPaddedColumns(keys, values) {
     maxKeyLength   = maxLength(keys);
     maxValueLength = maxLength(values);
 
+    columnSeparator = mongo_hacker_config['column_separator'];
+
     for (i = 0; i < keys.length; i++) {
         print(
             colorize(keys[i].pad(maxKeyLength, true), { color: 'green', bright: true })
-            + " - " // column separator...
+            + " " + columnSeparator + " "
             + values[i].pad(maxValueLength)
         );
     }

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -67,30 +67,14 @@ shellHelper.show = function (what) {
     }
 
     if (what == "dbs" || what == "databases") {
-        var dbinfo = [];
-        var maxNameLength = maxLength(db.getMongo().getDatabaseNames());
-        var maxGbDigits = 0;
-
-        db.getMongo().getDBs().databases.forEach(function (x){
-            var sizeStr = (x.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
-            var gbDigits = sizeStr.indexOf(".");
-
-            if( gbDigits > maxGbDigits ) maxGbDigits = gbDigits;
-
-            dbinfo.push({
-                name:      x.name,
-                size_str:  (x.sizeOnDisk > 1) ? (sizeStr + "GB") : "(empty)"
-            });
-        });
-
-        dbinfo.sort(function (a,b) { a.name - b.name });
-        dbinfo.forEach(function (db) {
-            print(
-              colorize(db.name.pad(maxNameLength, true), { color: 'green', bright: true })
-              + "  " + db.size_str.pad(maxGbDigits + 6) // xxx.000GB, so 6 trailing chars
-            );
-        });
-
+        var databaseNames = db.getMongo().getDBs().databases.reduce(function(names, db) {
+            return names.concat(db.name);
+        }, []);
+        var databaseSizes = db.getMongo().getDBs().databases.reduce(function(sizes, db) {
+            var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
+            return sizes.concat((db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)");
+        }, []);
+        printPaddedColumns(databaseNames, databaseSizes);
         return "";
     }
 

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -59,10 +59,14 @@ shellHelper.show = function (what) {
         var collectionSizes = collectionNames.map(function (name) {
             var stats = db.getCollection(name).stats();
             var size = (stats.size / 1024 / 1024).toFixed(3);
-            var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
-            return (size + "MB / " + storageSize + "MB");
+            return (size + "MB");
         });
-        printPaddedColumns(collectionNames, collectionSizes);
+        var collectionStorageSizes = collectionNames.map(function (name) {
+            var stats = db.getCollection(name).stats();
+            var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
+            return (storageSize + "MB");
+        });
+        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes));
         return "";
     }
 

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -67,13 +67,13 @@ shellHelper.show = function (what) {
     }
 
     if (what == "dbs" || what == "databases") {
-        var databaseNames = db.getMongo().getDBs().databases.reduce(function(names, db) {
-            return names.concat(db.name);
-        }, []);
-        var databaseSizes = db.getMongo().getDBs().databases.reduce(function(sizes, db) {
+        var databaseNames = db.getMongo().getDBs().databases.map(function(db) {
+            return db.name;
+        });
+        var databaseSizes = db.getMongo().getDBs().databases.map(function(db) {
             var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
-            return sizes.concat((db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)");
-        }, []);
+            return (db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)";
+        });
         printPaddedColumns(databaseNames, databaseSizes);
         return "";
     }

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -55,17 +55,14 @@ shellHelper.show = function (what) {
     }
 
     if (what == "collections" || what == "tables") {
-        var maxNameLength = maxLength(db.getCollectionNames());
-        db.getCollectionNames().forEach(function (collectionName) {
-          var stats = db.getCollection(collectionName).stats();
-          var size = (stats.size / 1024 / 1024).toFixed(3),
-              storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
-
-          print(
-            colorize(collectionName.pad(maxNameLength, true), { color: 'green', bright: true })
-            + "  " + size + "MB / " + storageSize + "MB"
-          );
+        var collectionNames = db.getCollectionNames();
+        var collectionSizes = collectionNames.map(function (name) {
+            var stats = db.getCollection(name).stats();
+            var size = (stats.size / 1024 / 1024).toFixed(3);
+            var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
+            return (size + "MB / " + storageSize + "MB");
         });
+        printPaddedColumns(collectionNames, collectionSizes);
         return "";
     }
 


### PR DESCRIPTION
Hey @TylerBrock,

This PR doesn't introduce any functional changes, but rather DRYs up similar, almost identical code that existed in the implementation of the following commands:

* `show dbs`
* `show collections`
* `count documents`

By introducing the `printPaddedColumns()` helper function, I was able to significantly simplify the implementation of these 3 commands, as the helper provides the formatting of padded/aligned columns, so that the commands only need to implement their respective logic without having to concern themselves about formatting their output.

The  `printPaddedColumns(keys, values)` helper works as follows:

* the so-called "keys" will be right-padded with spaces so that they align to the longest key string, and printed in the left-hand column
* the so-called "values" will be left-padded with spaces so that they align to the longest value string, and printed in the right-hand column
* the two columns will be separated by `" → "`, but this can be easily changed in `config.js`

The refactoring isn't completely backwards compatible: the layout of these 3 commands changes slightly, as illustrated by the below before _(left)_ & after _(right)_ screenshot, but arguably the layout is now more consistent and slightly easier to peruse.

![before_after](https://cloud.githubusercontent.com/assets/17322/7691065/72f547bc-fdaf-11e4-98e9-0065475b0966.png)

Thanks,

@pvdb
