### PR TITLE
Introducing: the new `count collections` shell helper :-)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The MongoDB shell offers various "shell commands" _(sometimes referred to as "sh
 
 To make interactive use of the MongoDB shell even more convenient, `mongo-hacker` adds the following shell commands:
 
+* `count collections`/`count tables`: count the number of collections in each of the mongo server's databases - by [@pvdb][pvdb]
 * `count documents`/`count docs`: count the number of documents in all _(non-`system`)_ collections in the database - by [@pvdb][pvdb]
 
 [interactive_versus_scripted]: http://docs.mongodb.org/manual/tutorial/write-scripts-for-the-mongo-shell/#differences-between-interactive-and-scripted-mongo

--- a/config.js
+++ b/config.js
@@ -37,7 +37,9 @@ mongo_hacker_config = {
     'binData':   { color: 'green', bright: true },
     'function':  { color: 'magenta' },
     'date':      { color: 'blue' },
-    'uuid':      { color: 'cyan' }
+    'uuid':      { color: 'cyan' },
+    'databaseNames':   { color: 'green', bright: true },
+    'collectionNames': { color: 'blue',  bright: true }
   }
 }
 

--- a/hacks/aggregation.js
+++ b/hacks/aggregation.js
@@ -28,7 +28,7 @@ DBCollection.prototype.aggregate = function( ops, extraOpts ){
         }
         return res;
     } else {
-       return new Aggregation( this ).match( ops || {} );
+        return new Aggregation( this ).match( ops || {} );
     }
 };
 

--- a/hacks/api.js
+++ b/hacks/api.js
@@ -85,12 +85,12 @@ DBQuery.prototype.update = function( update ){
 
 // Replace one document
 DBQuery.prototype.replace = function( replacement ){
-   assert( replacement , "need an update object" );
+    assert( replacement , "need an update object" );
 
-   this._validate(replacement);
-   this._db._initExtraInfo();
-   this._mongo.update( this._ns , this._query , replacement , false , false );
-   this._db._getExtraInfo("Replaced");
+    this._validate(replacement);
+    this._db._initExtraInfo();
+    this._mongo.update( this._ns , this._query , replacement , false , false );
+    this._db._getExtraInfo("Replaced");
 };
 
 // Remove is always multi

--- a/hacks/common.js
+++ b/hacks/common.js
@@ -153,7 +153,7 @@ function isInArray(array, value) {
 tojsonObject = function( x, indent, nolint, sort_keys ) {
     var lineEnding = nolint ? " " : "\n";
     var tabSpace = nolint ? "" : __indent;
-	var sortKeys = (null == sort_keys) ? mongo_hacker_config.sort_keys : sort_keys;
+    var sortKeys = (null == sort_keys) ? mongo_hacker_config.sort_keys : sort_keys;
 
     assert.eq( ( typeof x ) , "object" , "tojsonObject needs object, not [" + ( typeof x ) + "]" );
 

--- a/hacks/common.js
+++ b/hacks/common.js
@@ -197,9 +197,9 @@ tojsonObject = function( x, indent, nolint, sort_keys ) {
     if ( sortKeys ) {
         // Disable sorting if this object looks like an index spec
         if ( (isInArray(keylist, "v") && isInArray(keylist, "key") && isInArray(keylist, "name") && isInArray(keylist, "ns")) ) {
-           sortKeys = false;
+            sortKeys = false;
         } else {
-           keylist.sort();
+            keylist.sort();
         }
     }
 

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -6,6 +6,16 @@ shellHelper.count = function (what) {
     what = args[0]
     args = args.splice(1)
 
+    if (what == "collections" || what == "tables") {
+        databaseNames = db.getMongo().getDatabaseNames();
+        collectionCounts = databaseNames.map(function (databaseName) {
+            var count = db.getMongo().getDB(databaseName).getCollectionNames().length;
+            return (count.commify() + " collection(s)");
+        });
+        printPaddedColumns(databaseNames, collectionCounts);
+        return "";
+    }
+
     if (what == "documents" || what == "docs") {
         collectionNames = db.getCollectionNames().filter(function (collectionName) {
             // exclude "system" collections from "count" operation

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -12,7 +12,7 @@ shellHelper.count = function (what) {
             var count = db.getMongo().getDB(databaseName).getCollectionNames().length;
             return (count.commify() + " collection(s)");
         });
-        printPaddedColumns(databaseNames, collectionCounts);
+        printPaddedColumns(databaseNames, collectionCounts, 'green');
         return "";
     }
 
@@ -25,7 +25,7 @@ shellHelper.count = function (what) {
             var count = db.getCollection(collectionName).count();
             return (count.commify() + " document(s)");
         });
-        printPaddedColumns(collectionNames, documentCounts);
+        printPaddedColumns(collectionNames, documentCounts, 'blue');
         return "";
     }
 

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -12,7 +12,7 @@ shellHelper.count = function (what) {
             var count = db.getMongo().getDB(databaseName).getCollectionNames().length;
             return (count.commify() + " collection(s)");
         });
-        printPaddedColumns(databaseNames, collectionCounts, 'green');
+        printPaddedColumns(databaseNames, collectionCounts, mongo_hacker_config['colors']['databaseNames']);
         return "";
     }
 
@@ -25,7 +25,7 @@ shellHelper.count = function (what) {
             var count = db.getCollection(collectionName).count();
             return (count.commify() + " document(s)");
         });
-        printPaddedColumns(collectionNames, documentCounts, 'blue');
+        printPaddedColumns(collectionNames, documentCounts, mongo_hacker_config['colors']['collectionNames']);
         return "";
     }
 

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -67,12 +67,12 @@ function printPaddedColumns(keys, values, color) {
     columnSeparator = mongo_hacker_config['column_separator'];
 
     if (typeof color === 'undefined') {
-        color = 'gray';
+        color = { color: 'green', bright: true }
     }
 
     for (i = 0; i < keys.length; i++) {
         print(
-            colorize(keys[i].pad(maxKeyLength, true), { color: color, bright: true })
+            colorize(keys[i].pad(maxKeyLength, true), color)
             + " " + columnSeparator + " "
             + values[i].pad(maxValueLength)
         );

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -33,7 +33,7 @@ function getSlowms(){
 
 function maxLength(listOfNames) {
     return listOfNames.reduce(function(maxLength, name) {
-      return (name.length > maxLength) ? name.length : maxLength ;
+        return (name.length > maxLength) ? name.length : maxLength ;
     }, 0);
 };
 

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -58,7 +58,7 @@ function mergePaddedValues(leftHandValues, rightHandValues) {
     return combinedValues;
 }
 
-function printPaddedColumns(keys, values) {
+function printPaddedColumns(keys, values, color) {
     assert(keys.length == values.length);
 
     maxKeyLength   = maxLength(keys);
@@ -66,9 +66,13 @@ function printPaddedColumns(keys, values) {
 
     columnSeparator = mongo_hacker_config['column_separator'];
 
+    if (typeof color === 'undefined') {
+        color = 'gray';
+    }
+
     for (i = 0; i < keys.length; i++) {
         print(
-            colorize(keys[i].pad(maxKeyLength, true), { color: 'green', bright: true })
+            colorize(keys[i].pad(maxKeyLength, true), { color: color, bright: true })
             + " " + columnSeparator + " "
             + values[i].pad(maxValueLength)
         );

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -66,7 +66,7 @@ shellHelper.show = function (what) {
             var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
             return (storageSize + "MB");
         });
-        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes), 'blue');
+        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes), mongo_hacker_config['colors']['collectionNames']);
         return "";
     }
 
@@ -78,7 +78,7 @@ shellHelper.show = function (what) {
             var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
             return (db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)";
         });
-        printPaddedColumns(databaseNames, databaseSizes, 'green');
+        printPaddedColumns(databaseNames, databaseSizes, mongo_hacker_config['colors']['databaseNames']);
         return "";
     }
 

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -66,7 +66,7 @@ shellHelper.show = function (what) {
             var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
             return (storageSize + "MB");
         });
-        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes));
+        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes), 'blue');
         return "";
     }
 
@@ -78,7 +78,7 @@ shellHelper.show = function (what) {
             var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
             return (db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)";
         });
-        printPaddedColumns(databaseNames, databaseSizes);
+        printPaddedColumns(databaseNames, databaseSizes, 'green');
         return "";
     }
 


### PR DESCRIPTION
Hey @TylerBrock,

After all the prep work in previous pull requests, here it is - in all its glory - the new `count collections` shell helper!  :smile:

A typical _explorative_ workflow in the mongo shell - which I've captured in the attached screenshot - can now be something along the lines of:

1. `show dbs` - to find out which databases exist on the server, incl. an indication of their respective sizes
1. `count collections` - to find out how many collections exists in each of these databases
1. `use <database>` - to switch to a given database
1. `show collections` - to find out which collections exists in this database, incl. an indication of their respective sizes
1. `count documents` - to find out how many documents exists in each of these collections

As you can see on the screenshot, I've adopted a color scheme: green for *database* names, blue for *collection* names... if you agree that using different colors for databases and collections is a good idea, then please let me know if you prefer different colors... I've made them configurable via `config.js` so it'd be a doddle to change them!

![typical_workflow](https://cloud.githubusercontent.com/assets/17322/7714381/f8a70f78-fe75-11e4-872a-2da7b0a8c10f.png)
