### PR TITLE
Added an "indexStats()" helper to get sizes of all indexes by collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ To make interactive use of the MongoDB shell even more convenient, `mongo-hacker
 
 * `count collections`/`count tables`: count the number of collections in each of the mongo server's databases - by [@pvdb][pvdb]
 * `count documents`/`count docs`: count the number of documents in all _(non-`system`)_ collections in the database - by [@pvdb][pvdb]
+* `db.indexStats(['collectionName' [, bool details ]])`: list all collections and display the size of all indexes - by [@cog-g][cog-g]
 
 [interactive_versus_scripted]: http://docs.mongodb.org/manual/tutorial/write-scripts-for-the-mongo-shell/#differences-between-interactive-and-scripted-mongo
 
 [pvdb]: https://github.com/pvdb
+[cog-g]: https://github.com/Cog-g
 
 ### API Additions
 


### PR DESCRIPTION
It's sometime useful to see size of indexes across collections, to check what can or cannot fit in RAM.