### PR TITLE
Better DBRef

### DIFF
--- a/config.js
+++ b/config.js
@@ -23,6 +23,11 @@ mongo_hacker_config = {
   force_color:     false,           // force color highlighting for Windows users
   column_separator:  '→',           // separator used when printing padded/aligned columns
   value_separator:   '/',           // separator used when merging padded/aligned values
+  dbref: {
+    extended_info: true,            // enable more informations on DBRef
+    plain:         false,           // print DBRef as plain JSON object
+    db_if_differs: false            // include $db only if is different than current one
+  },
 
   // Shell Color Settings
   // Colors available: red, green, yellow, blue, magenta, cyan

--- a/hacks/dbref.js
+++ b/hacks/dbref.js
@@ -1,0 +1,28 @@
+DBRef.prototype.__toString = DBRef.prototype.toString;
+DBRef.prototype.toString = function () {
+  var org = this.__toString();
+  var config = mongo_hacker_config.dbref;
+  if (!config.extended_info) {
+    return org;
+  }
+  var additional = {};
+  var o = this;
+  for (var p in o) {
+    if (typeof o[p] === 'function') {
+      continue;
+    }
+    if (!config.plain && (p === '$ref' || p === '$id')) {
+      continue;
+    }
+    if (config.db_if_differs && p === '$db' && o[p] === db.getName()) {
+      continue;
+    }
+    additional[p] = o[p];
+  }
+  if (config.plain) {
+    return tojsonObject(additional, undefined, true);
+  }
+  return Object.keys(additional).length
+    ? (org.slice(0, -1) + ", " + tojsonObject(additional, undefined, true) + ")")
+    : org;
+};


### PR DESCRIPTION
Enhances how `DBRef` are printed since original implementation doesn't really care about showing optional `$db` field not mentioning any additional fields user (or his software, in my case [PHP's Doctrine ODM](https://github.com/doctrine/mongodb-odm)) may put there. Right now it looks like this (showcased all 4 combinations possible as of now, switching `mongo_hacker_config.dbref.extended_info` to `false` will bring back shell's default):

![](https://cloud.githubusercontent.com/assets/4947711/12292317/88d94ed0-b9ec-11e5-8840-4e47432ae724.png)

I believe styling could be improved but before I spend too much time polishing details I'd like to know whether PR will be accepted at all :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tylerbrock/mongo-hacker/145)
<!-- Reviewable:end -->
