### PR TITLE
Add "delta counts" to the "count document" commands

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2012, 2015 Tyler Brock
+Copyright (c) 2012, 2016 Tyler Brock
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ To make interactive use of the MongoDB shell even more convenient, `mongo-hacker
 * `count documents`/`count docs`: count the number of documents in all _(non-`system`)_ collections in the database - by [@pvdb][pvdb]
 * `count indexes`: list all collections and display the size of all indexes - by [@cog-g][cog-g]
 
+Some of these commands have hidden features that can be enabled in the `mongo-hacker` config, to make the command output even more useful:
+
+* by changing the `count_deltas` setting to `true` in `config.js`, the `count documents` command will also print out the change in the number of documents since the last count - by [@pvdb][pvdb]
+
 [interactive_versus_scripted]: http://docs.mongodb.org/manual/tutorial/write-scripts-for-the-mongo-shell/#differences-between-interactive-and-scripted-mongo
 
 [pvdb]: https://github.com/pvdb

--- a/config.js
+++ b/config.js
@@ -17,7 +17,7 @@ mongo_hacker_config = {
   sort_keys:      false,            // sort the keys in documents when displayed
   uuid_type:      'default',        // 'java', 'c#', 'python' or 'default'
   banner_message: 'Mongo-Hacker ',  // banner message
-  version:        '0.0.9',          // current mongo-hacker version
+  version:        '0.0.10',         // current mongo-hacker version
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users

--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@ mongo_hacker_config = {
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users
-  count_deltas:    true,            // "count documents" shows deltas with previous counts
+  count_deltas:    false,           // "count documents" shows deltas with previous counts
   column_separator:  '→',           // separator used when printing padded/aligned columns
   value_separator:   '/',           // separator used when merging padded/aligned values
 

--- a/config.js
+++ b/config.js
@@ -21,6 +21,7 @@ mongo_hacker_config = {
   show_banner:     true,            // show mongo-hacker version banner on startup
   windows_warning: true,            // show warning banner for windows
   force_color:     false,           // force color highlighting for Windows users
+  count_deltas:    true,            // "count documents" shows deltas with previous counts
   column_separator:  '→',           // separator used when printing padded/aligned columns
   value_separator:   '/',           // separator used when merging padded/aligned values
 

--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@
  * Mongo-Hacker
  * MongoDB Shell Enhancements for Hackers
  *
- * Tyler J. Brock - 2013 - 2015
+ * Tyler J. Brock - 2013 - 2016
  *
  * http://tylerbrock.github.com/mongo-hacker
  *

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -1,11 +1,19 @@
 // helper function to format delta counts
 function delta(currentCount, previousCount) {
     var delta = Number(currentCount - previousCount);
-    return isNaN(delta) ? colorize("(first count)", { color: 'blue' }) :
-        (delta == 0) ?  colorize("(=)", { color: 'blue' }) :
-            (delta > 0) ? colorize("(+" + delta.commify() + ")", { color: 'green' }) :
-                (delta < 0) ? colorize("(" + delta.commify() + ")", { color: 'red' }) :
-                    (delta + " not supported");
+    var formatted_delta;
+    if (isNaN(delta)) {
+      formatted_delta = colorize("(first count)", { color: 'blue' });
+    } else if (delta == 0) {
+      formatted_delta = colorize("(=)", { color: 'blue' });
+    } else if (delta > 0) {
+      formatted_delta = colorize("(+" + delta.commify() + ")", { color: 'green' });
+    } else if (delta < 0) {
+      formatted_delta = colorize("(" + delta.commify() + ")", { color: 'red' });
+    } else {
+      formatted_delta = (delta + " not supported");
+    }
+    return formatted_delta;
 }
 
 // global variable (to ensure "persistence" of document counts)

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -1,3 +1,19 @@
+function delta(currentCount, previousCount) {
+    if (!mongo_hacker_config['count_deltas']) {
+        return "";
+    }
+    var delta = Number(currentCount - previousCount);
+    delta = isNaN(delta) ? colorize("(first count)", { color: 'blue' }) :
+        (delta == 0) ?  colorize("(=)", { color: 'blue' }) :
+            (delta > 0) ? colorize("(+" + delta.commify() + ")", { color: 'green' }) :
+                (delta < 0) ? colorize("(" + delta.commify() + ")", { color: 'red' }) :
+                    (delta + " not supported");
+    return " / " + delta.pad(21); // FIXME use "dynamic" padding
+}
+
+// global variable (to ensure "persistence")
+shellHelper.previousDocumentCount = {};
+
 // "count documents", a bit akin to "show collections"
 shellHelper.count = function (what) {
     assert(typeof what == "string");
@@ -22,8 +38,14 @@ shellHelper.count = function (what) {
             return !collectionName.startsWith('system.');
         });
         documentCounts = collectionNames.map(function (collectionName) {
+            // retrieve the previous document count for this collection
+            var previous = shellHelper.previousDocumentCount[collectionName];
+            // determine the current document count for this collection
             var count = db.getCollection(collectionName).count();
-            return (count.commify() + " document(s)");
+            // update the stored document count for this collection
+            shellHelper.previousDocumentCount[collectionName] = count;
+            // format the current document count, incl. delta since last count
+            return (count.commify() + " document(s)" + delta(count, previous));
         });
         printPaddedColumns(collectionNames, documentCounts, mongo_hacker_config['colors']['collectionNames']);
         return "";

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -1,14 +1,11 @@
+// helper function to format delta counts
 function delta(currentCount, previousCount) {
-    if (!mongo_hacker_config['count_deltas']) {
-        return "";
-    }
     var delta = Number(currentCount - previousCount);
-    delta = isNaN(delta) ? colorize("(first count)", { color: 'blue' }) :
+    return isNaN(delta) ? colorize("(first count)", { color: 'blue' }) :
         (delta == 0) ?  colorize("(=)", { color: 'blue' }) :
             (delta > 0) ? colorize("(+" + delta.commify() + ")", { color: 'green' }) :
                 (delta < 0) ? colorize("(" + delta.commify() + ")", { color: 'red' }) :
                     (delta + " not supported");
-    return " / " + delta.pad(21); // FIXME use "dynamic" padding
 }
 
 // global variable (to ensure "persistence")
@@ -39,17 +36,26 @@ shellHelper.count = function (what) {
             return !collectionName.startsWith('system.');
         });
         documentCounts = collectionNames.map(function (collectionName) {
+            var count = db.getCollection(collectionName).count();
+            return (count.commify() + " document(s)");
+        });
+        deltaCounts = collectionNames.map(function (collectionName) {
             // retrieve the previous document count for this collection
             var previous = shellHelper.previousDocumentCount[collectionName];
             // determine the current document count for this collection
-            var count = db.getCollection(collectionName).count();
+            var current = db.getCollection(collectionName).count();
             // update the stored document count for this collection
-            shellHelper.previousDocumentCount[collectionName] = count;
-            // format the current document count, incl. delta since last count
-            return (count.commify() + " document(s)" + delta(count, previous));
+            shellHelper.previousDocumentCount[collectionName] = current;
+            // format the delta since last count
+            return delta(current, previous);
         });
         collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
-        printPaddedColumns(collectionNames, documentCounts);
+        if (mongo_hacker_config['count_deltas']) {
+            printPaddedColumns(collectionNames, documentCounts, deltaCounts);
+        } else {
+            printPaddedColumns(collectionNames, documentCounts);
+        }
+
         return "";
     }
 

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -8,7 +8,7 @@ function delta(currentCount, previousCount) {
                     (delta + " not supported");
 }
 
-// global variable (to ensure "persistence")
+// global variable (to ensure "persistence" of document counts)
 shellHelper.previousDocumentCount = {};
 
 // "count documents", a bit akin to "show collections"


### PR DESCRIPTION
Hey @TylerBrock,

This is an extension that I've been sitting on for a while now, but people I pair with find it very useful, so I'm submitting it for your consideration... in a nutshell, the `count documents` command now includes - for each collection - the "delta count" since it was last invoked.

A picture speaks a thousand words, or so they say :smile:

![screen shot 2016-02-10 at 12 47 39](https://cloud.githubusercontent.com/assets/17322/12947615/863b55d8-cff4-11e5-8a0c-145205366720.png)

I find the feature most useful to "visualize" the effect of performing application actions on the collections in the database, e.g. placing an order _(in the application)_ might create a new customer, a new order, and several new order lines _(in the respective database collections)_.

Running `count documents` before and after performing the application action gives you a nice summary of that dynamic.

Hope you like it,

@pvdb

PS - as you'll see in the code, you can set `mongo_hacker_config['count_deltas'] = false` to suppress/disable this new feature, in which case `count documents` behaves exactly as before.