### PR TITLE
Refactor coloring database/collection names

### DIFF
--- a/hacks/color.js
+++ b/hacks/color.js
@@ -51,3 +51,9 @@ function colorize( string, color, nocolor ) {
 
     return applyColorCode( string, params, nocolor );
 };
+
+function colorizeAll( strings, color, nocolor ) {
+    return strings.map(function(string) {
+        return colorize( string, color, nocolor );
+    });
+};

--- a/hacks/count.js
+++ b/hacks/count.js
@@ -12,7 +12,8 @@ shellHelper.count = function (what) {
             var count = db.getMongo().getDB(databaseName).getCollectionNames().length;
             return (count.commify() + " collection(s)");
         });
-        printPaddedColumns(databaseNames, collectionCounts, mongo_hacker_config['colors']['databaseNames']);
+        databaseNames = colorizeAll(databaseNames, mongo_hacker_config['colors']['databaseNames']);
+        printPaddedColumns(databaseNames, collectionCounts);
         return "";
     }
 
@@ -25,7 +26,8 @@ shellHelper.count = function (what) {
             var count = db.getCollection(collectionName).count();
             return (count.commify() + " document(s)");
         });
-        printPaddedColumns(collectionNames, documentCounts, mongo_hacker_config['colors']['collectionNames']);
+        collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
+        printPaddedColumns(collectionNames, documentCounts);
         return "";
     }
 

--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -58,7 +58,7 @@ function mergePaddedValues(leftHandValues, rightHandValues) {
     return combinedValues;
 }
 
-function printPaddedColumns(keys, values, color) {
+function printPaddedColumns(keys, values) {
     assert(keys.length == values.length);
 
     maxKeyLength   = maxLength(keys);
@@ -66,13 +66,9 @@ function printPaddedColumns(keys, values, color) {
 
     columnSeparator = mongo_hacker_config['column_separator'];
 
-    if (typeof color === 'undefined') {
-        color = { color: 'green', bright: true }
-    }
-
     for (i = 0; i < keys.length; i++) {
         print(
-            colorize(keys[i].pad(maxKeyLength, true), color)
+            keys[i].pad(maxKeyLength, true)
             + " " + columnSeparator + " "
             + values[i].pad(maxValueLength)
         );

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -66,7 +66,8 @@ shellHelper.show = function (what) {
             var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
             return (storageSize + "MB");
         });
-        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes), mongo_hacker_config['colors']['collectionNames']);
+        collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
+        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes));
         return "";
     }
 
@@ -79,7 +80,8 @@ shellHelper.show = function (what) {
             var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
             return (db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)";
         });
-        printPaddedColumns(databaseNames, databaseSizes, mongo_hacker_config['colors']['databaseNames']);
+        databaseNames = colorizeAll(databaseNames, mongo_hacker_config['colors']['databaseNames']);
+        printPaddedColumns(databaseNames, databaseSizes);
         return "";
     }
 


### PR DESCRIPTION
Hey @TylerBrock, this PR contains some refactoring _(but no functional changes)_ to the way database and collection names are colorized for the various `show` and `count` shell commands... as a consequence of this refactoring, the `printPaddedColumns()` function is simplified, as it no longer needs to concern itself with coloring any of its columns... this refactoring is prep-work for enabling the `printPaddedColumns()` function to print out multiple columns _(instead of just printing out two, as it currently does)_.

Basically it's a bit of refactoring to enable the multi-column output/formatting we need for #148