### PR TITLE
Handle multiple (ie. more than 2) columns

### DIFF
--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -37,40 +37,28 @@ function maxLength(listOfNames) {
     }, 0);
 };
 
-function mergePaddedValues(leftHandValues, rightHandValues) {
-    assert(leftHandValues.length == rightHandValues.length);
+function printPaddedColumns() {
+    var columnWidths = Array.prototype.map.call(
+      arguments,
+      function(column) {
+        return maxLength(column);
+      }
+    );
 
-    maxLeftHandValueLength = maxLength(leftHandValues);
-    maxRightHandValueLength = maxLength(rightHandValues);
-
-    valueSeparator = mongo_hacker_config['value_separator'];
-
-    var combinedValues = []
-
-    for (i = 0; i < leftHandValues.length; i++) {
-        combinedValues[i] = (
-            leftHandValues[i].pad(maxLeftHandValueLength)
-            + " " + valueSeparator + " "
-            + rightHandValues[i].pad(maxRightHandValueLength)
-        );
+    for (i = 0; i < arguments[0].length; i++) {
+        row = "";
+        for (j = 0; j < arguments.length; j++) {
+            row += arguments[j][i].toString().pad(columnWidths[j], (j == 0));
+            if (j < (arguments.length - 1)) {
+                separator = ((j == 0) ?
+                    mongo_hacker_config['column_separator'] :
+                    mongo_hacker_config['value_separator']
+                );
+                row += " " + separator + " ";
+            }
+        }
+        print(row);
     }
 
-    return combinedValues;
-}
-
-function printPaddedColumns(keys, values) {
-    assert(keys.length == values.length);
-
-    maxKeyLength   = maxLength(keys);
-    maxValueLength = maxLength(values);
-
-    columnSeparator = mongo_hacker_config['column_separator'];
-
-    for (i = 0; i < keys.length; i++) {
-        print(
-            keys[i].pad(maxKeyLength, true)
-            + " " + columnSeparator + " "
-            + values[i].pad(maxValueLength)
-        );
-    }
+    return null;
 };

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -67,7 +67,7 @@ shellHelper.show = function (what) {
             return (storageSize + "MB");
         });
         collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
-        printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes));
+        printPaddedColumns(collectionNames, collectionSizes, collectionStorageSizes);
         return "";
     }
 


### PR DESCRIPTION
Hey @TylerBrock,

In https://github.com/TylerBrock/mongo-hacker/pull/148#discussion_r51252848 I wrote:
>  [it] requires a pretty significant refactor of the `printPaddedColumns()` function in `hacks/helpers/js`, mainly to support multiple columns _(instead of just two, which it does currently)_

... here it is, in all its glory, the refactoring of  `printPaddedColumns()` to support multiple _(ie. more than 2)_ colums.

The `printPaddedColumns()` function has changed so much that the GitHub diff is probably meaningless, so probably better to just grok the new version.

Thanks to the new implementation, though, I was able to get rid of the now-superfluous `mergePaddedValues()` function, as that function just made up for the lack of proper multi-column support in `printPaddedColumns()`.

The main benefits of this new version are (1) how it simplifies printing out multiple padded columns, and (2) how it supports a variable number of columns _(1 upto ∞, in theory at least :smile:)_:

**before**

```js
printPaddedColumns(collectionNames, mergePaddedValues(collectionSizes, collectionStorageSizes));
```

**after**

```js
printPaddedColumns(collectionNames, collectionSizes, collectionStorageSizes);
```

... which will enable me to merge this into #148 to implement the "dynamic" padding you wanted to fix first.

Going forward, this function can be used to print and layout even more columns, not just the three that we have at the moment:

```shell
macpvandenb(mongod-3.2.1) test> printPaddedColumns(["first", "second", "third"], ["foo", 2, 3], [4, "bar", 6], [7, 8, "qux"], [0, "blegga", 0])
first  → foo /   4 /   7 /      0
second →   2 / bar /   8 / blegga
third  →   3 /   6 / qux /      0
null
macpvandenb(mongod-3.2.1) test> _
```

BTW: this PR is again a pure refactoring of existing logic, it doesn't change anything functionally, as you can verify by running the `show dbs`, `count collections`, `show collections`, and `count documents` shell commands... they behave exactly as before, and their output is identical. So much win!  :smile: