### PR TITLE
Reverted Fix #13 which interferes with ReplSetTest() command

### DIFF
--- a/hacks/common.js
+++ b/hacks/common.js
@@ -256,11 +256,6 @@ tojson = function( x, indent , nolint, nocolor, sort_keys ) {
 
     var sortKeys = (null == sort_keys) ? mongo_hacker_config.sort_keys : sort_keys;
 
-    if (null == tojson.caller) {
-        // Unknonwn caller context, so assume this is from C++ code
-        nocolor = true;
-    }
-
     if ( x === null )
         return colorize("null", mongo_hacker_config.colors['null'], nocolor);
 

--- a/hacks/random.js
+++ b/hacks/random.js
@@ -1,0 +1,73 @@
+var random = {
+
+    _phonetics : [
+        "Alpha", "Bravo", "Charlie", "Delta", "Echo",
+        "Foxtrot", "Golf", "Hotel", "India", "Juliet",
+        "Kilo", "Lima", "Mike", "November", "Oscar",
+        "Papa", "Quebec", "Romeo", "Sierra", "Tango",
+        "Unicorn", "Victor", "Whiskey", "Xray", "Yankee", "Zulu",
+        "Able","Baker","Charlie","Dog","Easy",
+        "Fox","George","How","Item","Jig",
+        "King","Love","Mike","Nan","Oboe",
+        "Peter","Queen","Roger","Sugar","Tare",
+        "Uncle","Victor","William","X-ray","Yoke","Zebra"
+    ],
+
+    _numstr : "0123456789",
+
+    _randint : function(maxval) {
+        return Math.floor(Math.random() * maxval);
+    },
+
+    keyval : function() {
+        var out = {};
+        for (var i = 0; i < arguments.length; i+=2) {
+            out[arguments[i]] = arguments[i+1]();
+        }
+        return out;
+    },
+
+    array : function(n, func) {
+        var out = [];
+        for (var i = 0; i < n; i++) {
+            out.push(func());
+        }
+        return out;
+    },
+
+    string : function(n, words) {
+        var words = words || random._phonetics;
+        var n = n || 1;
+        var len = words.length;
+        var out = random.array(n, function(){return words[random._randint(len)]});
+        return out.join(" ");
+    },
+
+    char : function(n) {
+        var out = "";
+        while (out.length < n) {
+            out += random.string() + " ";
+        }
+        return out.slice(0, n);
+    },
+
+    number : function(len,frac) {
+        switch (arguments.length) {
+            case 0:
+                var len = 3;
+            case 1:
+                var out = random.array(len, function(){return random._numstr[random._randint(10)]});
+                return Number(out.join(""));
+            case 2:
+                return Number(random.number(len) + "." + random.number(frac));
+        }
+    },
+
+    date : function(year) {
+        year = year || (new Date()).getFullYear();
+        return new Date(year, random._randint(12), random._randint(30) + 1, 0, 0, random._randint(86400));
+    }
+
+}
+
+var r = random;

--- a/hacks/random.js
+++ b/hacks/random.js
@@ -15,8 +15,13 @@ var random = {
 
     _numstr : "0123456789",
 
-    _randint : function(maxval) {
-        return Math.floor(Math.random() * maxval);
+    randint : function(a, b) {
+        switch (arguments.length) {
+            case 1:
+                return Math.floor(Math.random() * a);
+            default:
+                return a + Math.floor(Math.random() * (b-a));
+        }
     },
 
     keyval : function() {
@@ -39,7 +44,7 @@ var random = {
         var words = words || random._phonetics;
         var n = n || 1;
         var len = words.length;
-        var out = random.array(n, function(){return words[random._randint(len)]});
+        var out = random.array(n, function(){return words[random.randint(len)]});
         return out.join(" ");
     },
 
@@ -56,7 +61,7 @@ var random = {
             case 0:
                 var len = 3;
             case 1:
-                var out = random.array(len, function(){return random._numstr[random._randint(10)]});
+                var out = random.array(len, function(){return random._numstr[random.randint(10)]});
                 return Number(out.join(""));
             case 2:
                 return Number(random.number(len) + "." + random.number(frac));
@@ -65,7 +70,7 @@ var random = {
 
     date : function(year) {
         year = year || (new Date()).getFullYear();
-        return new Date(year, random._randint(12), random._randint(30) + 1, 0, 0, random._randint(86400));
+        return new Date(year, random.randint(12), random.randint(30) + 1, 0, 0, random.randint(86400));
     }
 
 }

--- a/hacks/random.js
+++ b/hacks/random.js
@@ -61,7 +61,8 @@ var random = {
             case 0:
                 var len = 3;
             case 1:
-                var out = random.array(len, function(){return random._numstr[random.randint(10)]});
+                var out = (len > 0) ? [random.randint(1,10)] : [0];
+                out = out.concat(random.array(len-1, function(){return random._numstr[random.randint(10)]}));
                 return Number(out.join(""));
             case 2:
                 return Number(random.number(len) + "." + random.number(frac));


### PR DESCRIPTION
Trying to run a test replica set by using:

```
> var r = ReplSetTest({nodes:3})
> r.startSet()
```

failed with error:

```
TypeError: access to strict mode caller function is censored
```

This is because calling `.caller` method is blocked in the latest version of `mongo`. This patch should fix the issue.