### PR TITLE
Reverted Fix #13 which interferes with ReplSetTest() command

### DIFF
--- a/hacks/common.js
+++ b/hacks/common.js
@@ -256,11 +256,6 @@ tojson = function( x, indent , nolint, nocolor, sort_keys ) {
 
     var sortKeys = (null == sort_keys) ? mongo_hacker_config.sort_keys : sort_keys;
 
-    if (null == tojson.caller) {
-        // Unknonwn caller context, so assume this is from C++ code
-        nocolor = true;
-    }
-
     if ( x === null )
         return colorize("null", mongo_hacker_config.colors['null'], nocolor);
 


### PR DESCRIPTION
Trying to run a test replica set by using:

    > var rst = new ReplSetTest({nodes:3})
    > rst.startSet()

failed with error:

    TypeError: access to strict mode caller function is censored

This is because calling .caller method is blocked in the latest version of mongo. Removing the `tojson.caller` call fixed the issue.

This is from my earlier pull request, I think it's fixed now. Sorry for the delay in resubmitting.
