### PR TITLE
Add Support For 3.4 Show Commands

### DIFF
--- a/hacks/helpers.js
+++ b/hacks/helpers.js
@@ -48,14 +48,17 @@ function printPaddedColumns() {
     for (i = 0; i < arguments[0].length; i++) {
         row = "";
         for (j = 0; j < arguments.length; j++) {
-            row += arguments[j][i].toString().pad(columnWidths[j], (j == 0));
-            if (j < (arguments.length - 1)) {
-                separator = ((j == 0) ?
+            var separator = ""
+            var val = arguments[j][i].toString();
+            if (!val && j >= arguments.length - 1) { continue; }
+            val = val.pad(columnWidths[j], (j == 0));
+            if (j > 0) {
+                separator = " " + ((j == 1) ?
                     mongo_hacker_config['column_separator'] :
                     mongo_hacker_config['value_separator']
-                );
-                row += " " + separator + " ";
+                ) + " ";
             }
+            row += separator + val;
         }
         print(row);
     }

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -160,6 +160,39 @@ shellHelper.show = function (what) {
         }
     }
 
+    if (what == "automationNotices") {
+        var dbDeclared, ex;
+        try {
+            // !!db essentially casts db to a boolean
+            // Will throw a reference exception if db hasn't been declared.
+            dbDeclared = !!db;
+        } catch (ex) {
+            dbDeclared = false;
+        }
+
+        if (dbDeclared) {
+            var res = db.runCommand({isMaster: 1, forShell: 1});
+            if (!res.ok) {
+                print("Note: Cannot determine if automation is active");
+                return "";
+            }
+
+            if (res.hasOwnProperty("automationServiceDescriptor")) {
+                print("Note: This server is managed by automation service '" +
+                      res.automationServiceDescriptor + "'.");
+                print(
+                    "Note: Many administrative actions are inappropriate, and may be automatically reverted.");
+                return "";
+            }
+
+            return "";
+
+        } else {
+            print("Cannot show automationNotices, \"db\" is not set");
+            return "";
+        }
+    }
+
     throw "don't know how to show [" + what + "]";
 
 }

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -1,198 +1,49 @@
 // Better show dbs
-shellHelper.show = function (what) {
-    assert(typeof what == "string");
+shellHelper.show = function () {
+    var show = shellHelper.show;
+    return function (what) {
+        assert(typeof what == "string");
 
-    var args = what.split( /\s+/ );
-    what = args[0]
-    args = args.splice(1)
-
-    if (what == "profile") {
-        if (db.system.profile.count() == 0) {
-            print("db.system.profile is empty");
-            print("Use db.setProfilingLevel(2) will enable profiling");
-            print("Use db.system.profile.find() to show raw profile entries");
-        }
-        else {
-            print();
-            db.system.profile.find({ millis: { $gt: 0} }).sort({ $natural: -1 }).limit(5).forEach(
-                function (x) {
-                    print("" + x.op + "\t" + x.ns + " " + x.millis + "ms " + String(x.ts).substring(0, 24));
-                    var l = "";
-                    for ( var z in x ){
-                        if ( z == "op" || z == "ns" || z == "millis" || z == "ts" )
-                            continue;
-
-                        var val = x[z];
-                        var mytype = typeof(val);
-
-                        if ( mytype == "string" ||
-                             mytype == "number" )
-                            l += z + ":" + val + " ";
-                        else if ( mytype == "object" )
-                            l += z + ":" + tojson(val ) + " ";
-                        else if ( mytype == "boolean" )
-                            l += z + " ";
-                        else
-                            l += z + ":" + val + " ";
-
-                    }
-                    print( l );
-                    print("\n");
+        if (what == "collections" || what == "tables") {
+            var collectionNames = db.getCollectionNames();
+            var collectionStats = collectionNames.map(function (name) {
+                var stats = db.getCollection(name).stats();
+                if (stats.ok) {
+                var size = (stats.size / 1024 / 1024).toFixed(3);
+                return (size + "MB");
+                } else if (stats.code === 166) {
+                return "VIEW";
+                } else {
+                return "ERR:" + stats.code;
                 }
-            )
-        }
-        return "";
-    }
-
-    if (what == "users") {
-        db.getUsers().forEach(printjson);
-        return "";
-    }
-
-    if (what == "roles") {
-        db.getRoles({showBuiltinRoles: true}).forEach(printjson);
-        return "";
-    }
-
-    if (what == "collections" || what == "tables") {
-        var collectionNames = db.getCollectionNames();
-        var collectionStats = collectionNames.map(function (name) {
-            var stats = db.getCollection(name).stats();
-            if (stats.ok) {
-              var size = (stats.size / 1024 / 1024).toFixed(3);
-              return (size + "MB");
-            } else if (stats.code === 166) {
-              return "VIEW";
-            } else {
-              return "ERR:" + stats.code;
-            }
-        });
-        var collectionStorageSizes = collectionNames.map(function (name) {
-            var stats = db.getCollection(name).stats();
-            if (stats.ok) {
-              var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
-              return (storageSize + "MB");
-            }
-            return "";
-        });
-        collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
-        printPaddedColumns(collectionNames, collectionStats, collectionStorageSizes);
-        return "";
-    }
-
-    if (what == "dbs" || what == "databases") {
-        var databases = db.getMongo().getDBs().databases.sort(function(a, b) { return a.name.localeCompare(b.name) });
-        var databaseNames = databases.map(function(db) {
-            return db.name;
-        });
-        var databaseSizes = databases.map(function(db) {
-            var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
-            return (db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)";
-        });
-        databaseNames = colorizeAll(databaseNames, mongo_hacker_config['colors']['databaseNames']);
-        printPaddedColumns(databaseNames, databaseSizes);
-        return "";
-    }
-
-    if (what == "log" ) {
-        var n = "global";
-        if ( args.length > 0 )
-            n = args[0]
-
-        var res = db.adminCommand( { getLog : n } );
-        if ( ! res.ok ) {
-            print("Error while trying to show " + n + " log: " + res.errmsg);
-            return "";
-        }
-        for ( var i=0; i<res.log.length; i++){
-            print( res.log[i] )
-        }
-        return ""
-    }
-
-    if (what == "logs" ) {
-        var res = db.adminCommand( { getLog : "*" } )
-        if ( ! res.ok ) {
-            print("Error while trying to show logs: " + res.errmsg);
-            return "";
-        }
-        for ( var i=0; i<res.names.length; i++){
-            print( res.names[i] )
-        }
-        return ""
-    }
-
-    if (what == "startupWarnings" ) {
-        var dbDeclared, ex;
-        try {
-            // !!db essentially casts db to a boolean
-            // Will throw a reference exception if db hasn't been declared.
-            dbDeclared = !!db;
-        } catch (ex) {
-            dbDeclared = false;
-        }
-        if (dbDeclared) {
-            var res = db.adminCommand( { getLog : "startupWarnings" } );
-            if ( res.ok ) {
-                if (res.log.length == 0) {
-                    return "";
-                }
-                print( "Server has startup warnings: " );
-                for ( var i=0; i<res.log.length; i++){
-                    print( res.log[i] )
+            });
+            var collectionStorageSizes = collectionNames.map(function (name) {
+                var stats = db.getCollection(name).stats();
+                if (stats.ok) {
+                var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
+                return (storageSize + "MB");
                 }
                 return "";
-            } else if (res.errmsg == "no such cmd: getLog" ) {
-                // Don't print if the command is not available
-                return "";
-            } else if (res.code == 13 /*unauthorized*/ ||
-                       res.errmsg == "unauthorized" ||
-                       res.errmsg == "need to login") {
-                // Don't print if startupWarnings command failed due to auth
-                return "";
-            } else {
-                print("Error while trying to show server startup warnings: " + res.errmsg);
-                return "";
-            }
-        } else {
-            print("Cannot show startupWarnings, \"db\" is not set");
+            });
+            collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
+            printPaddedColumns(collectionNames, collectionStats, collectionStorageSizes);
             return "";
         }
+
+        if (what == "dbs" || what == "databases") {
+            var databases = db.getMongo().getDBs().databases.sort(function(a, b) { return a.name.localeCompare(b.name) });
+            var databaseNames = databases.map(function(db) {
+                return db.name;
+            });
+            var databaseSizes = databases.map(function(db) {
+                var sizeInGigaBytes = (db.sizeOnDisk / 1024 / 1024 / 1024).toFixed(3);
+                return (db.sizeOnDisk > 1) ? (sizeInGigaBytes + "GB") : "(empty)";
+            });
+            databaseNames = colorizeAll(databaseNames, mongo_hacker_config['colors']['databaseNames']);
+            printPaddedColumns(databaseNames, databaseSizes);
+            return "";
+        }
+
+        return show(what);
     }
-
-    if (what == "automationNotices") {
-        var dbDeclared, ex;
-        try {
-            // !!db essentially casts db to a boolean
-            // Will throw a reference exception if db hasn't been declared.
-            dbDeclared = !!db;
-        } catch (ex) {
-            dbDeclared = false;
-        }
-
-        if (dbDeclared) {
-            var res = db.runCommand({isMaster: 1, forShell: 1});
-            if (!res.ok) {
-                print("Note: Cannot determine if automation is active");
-                return "";
-            }
-
-            if (res.hasOwnProperty("automationServiceDescriptor")) {
-                print("Note: This server is managed by automation service '" +
-                      res.automationServiceDescriptor + "'.");
-                print(
-                    "Note: Many administrative actions are inappropriate, and may be automatically reverted.");
-                return "";
-            }
-
-            return "";
-
-        } else {
-            print("Cannot show automationNotices, \"db\" is not set");
-            return "";
-        }
-    }
-
-    throw "don't know how to show [" + what + "]";
-
-}
+}();

--- a/hacks/show.js
+++ b/hacks/show.js
@@ -56,18 +56,27 @@ shellHelper.show = function (what) {
 
     if (what == "collections" || what == "tables") {
         var collectionNames = db.getCollectionNames();
-        var collectionSizes = collectionNames.map(function (name) {
+        var collectionStats = collectionNames.map(function (name) {
             var stats = db.getCollection(name).stats();
-            var size = (stats.size / 1024 / 1024).toFixed(3);
-            return (size + "MB");
+            if (stats.ok) {
+              var size = (stats.size / 1024 / 1024).toFixed(3);
+              return (size + "MB");
+            } else if (stats.code === 166) {
+              return "VIEW";
+            } else {
+              return "ERR:" + stats.code;
+            }
         });
         var collectionStorageSizes = collectionNames.map(function (name) {
             var stats = db.getCollection(name).stats();
-            var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
-            return (storageSize + "MB");
+            if (stats.ok) {
+              var storageSize = (stats.storageSize / 1024 / 1024).toFixed(3);
+              return (storageSize + "MB");
+            }
+            return "";
         });
         collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
-        printPaddedColumns(collectionNames, collectionSizes, collectionStorageSizes);
+        printPaddedColumns(collectionNames, collectionStats, collectionStorageSizes);
         return "";
     }
 


### PR DESCRIPTION
A couple features set to be released with MongoDB 3.4 (views and automation notices) make changes to `shellHelper.show`. This PR has the following changes:

1. Switch from completely duplicating and modifying `shellHelper.show` to wrapping the existing function and only overriding select commands. This will take care of support for `show automationNotices` as well as any future additions to `show`.

2. Modify the behavior `show tables` / `show collections`and `printPaddedColumns` to account for views and error codes:

```
laptop:27018(mongod-3.4.0-rc2) test> show tables
system.indexes → 0.000MB / 0.008MB
system.views   → 0.000MB / 0.008MB
test           → 0.000MB / 0.008MB
testView       →    VIEW
```

This isn't necessarily a complete list of the changes in 3.4, just the issues I ran into while using mongo-hacker with the development and release candidate builds.