### PR TITLE
Added an extra installation section on README.md file to install it from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@
 npm install -g mongo-hacker
 ```
 
+
+#### Install from source
+```
+git clone https://github.com/TylerBrock/mongo-hacker
+cd mongo-hacker
+make install
+cd ..
+rm -rdf mongo-hacker/
+```
+
 ## Enhancements
 
 #### Basic UX


### PR DESCRIPTION
Added an extra installation section on README.md file to install it from source clonning from github, it will help the people whith permission issues during the install process to avoid it.

It's not a final solution, but it's a way to get mongo-hacker install anyway on *nix OSes