### PR TITLE
Remove extra parenthesis from UUID formatting

### DIFF
--- a/hacks/common.js
+++ b/hacks/common.js
@@ -80,7 +80,7 @@ BinData.prototype.tojson = function(indent , nolint, nocolor) {
         output += colorize('"' + uuidType + '"', uuidColor)
         return surround('UUID', output);
     } else if (this.subtype() === 4) {
-        var output = colorize('"' + uuidToString(this, "default") + '"', uuidColor, nocolor) + ')'
+        var output = colorize('"' + uuidToString(this, "default") + '"', uuidColor, nocolor)
         return surround('UUID', output);
     } else {
         var output = colorize(this.subtype(), {color: 'red'}) + ', '


### PR DESCRIPTION
This: 

    BinData(4,"+QmLB2RiSEiqG3RgczsnKA==")

was formatted with trailing parenthesis:

    UUID("f9098b07-6462-4848-aa1b-7460733b2728"))