### PR TITLE
first attempt to fix aggregation issue #182

### DIFF
--- a/hacks/aggregation.js
+++ b/hacks/aggregation.js
@@ -19,14 +19,18 @@ DBCollection.prototype.aggregate = function( ops, extraOpts ){
         }
 
         var cmd = {pipeline: arr};
-        Object.extend(cmd, extraOpts);
+        // Object.extend(cmd, extraOpts);
+        
+        var cmdObj = this._makeCommand("aggregate", cmd);
 
-        var res = this.runCommand("aggregate", cmd);
+        return this._db._runAggregate(cmdObj, extraOpts);
+        /* var res = this.runCommand("aggregate", cmd);
         if (!res.ok) {
             printStackTrace();
             throw "aggregate failed: " + tojson(res);
         }
         return res;
+        */
     } else {
         return new Aggregation( this ).match( ops || {} );
     }


### PR DESCRIPTION
This fixes the `db.coll.aggregate([...])` with an array. But not with the helpers that this library has

```
Gianfrancos-MacBook-Pro(mongod-4.0.0) test> db.coll.aggregate([{ $project: { location: { $indexOfBytes: ["$string", "world"] } } }])
{ "_id": ObjectId("5b54a352214a68545d311e40"), "location": 6 }
Fetched 1 record(s) in 0ms
```

e.g. this will still no work: `db.coll.aggregate({})`

```
2018-07-22T19:49:06.255+0300 E QUERY    [js] uncaught exception: aggregation failed: {
  "ok": 0,
  "errmsg": "The 'cursor' option is required, except for aggregate with the explain argument",
  "code": 9,
  "codeName": "FailedToParse"
}
```

PS: I'm also not sure if the `explain` is doing anything now