### PR TITLE
Fixed #182: "The 'cursor' option is required"

### DIFF
--- a/hacks/aggregation.js
+++ b/hacks/aggregation.js
@@ -18,6 +18,10 @@ DBCollection.prototype.aggregate = function( ops, extraOpts ){
             extraOpts = {};
         }
 
+        if (extraOpts.cursor === undefined){
+            extraOpts.cursor = {batchSize: 1000};
+        }
+
         var cmd = {pipeline: arr};
         Object.extend(cmd, extraOpts);
 


### PR DESCRIPTION
This fixes the Mongodb 3.6+ error message "failedToParse: The 'cursor' option is required, except for aggregate with the explain argument" for aggregates