### PR TITLE
Add records count in 'show collections'

### DIFF
--- a/hacks/show.js
+++ b/hacks/show.js
@@ -25,8 +25,20 @@ shellHelper.show = function () {
                 }
                 return "";
             });
+            var collectionDocCount = collectionNames.map(function (name) {
+              var stats = db.getCollection(name).stats();
+              if (stats.ok) {
+                var strCount = stats.count.toString();
+                var rgx = /(\d+)(\d{3})/;
+                while (rgx.test(strCount)) {
+                  strCount = strCount.replace(rgx, '$1' + ',' + '$2');
+                }
+                return (strCount + " r(s)");
+              }
+              return "";
+            });
             collectionNames = colorizeAll(collectionNames, mongo_hacker_config['colors']['collectionNames']);
-            printPaddedColumns(collectionNames, collectionStats, collectionStorageSizes);
+            printPaddedColumns(collectionNames, collectionStats, collectionStorageSizes, collectionDocCount);
             return "";
         }
 


### PR DESCRIPTION
<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->
I've added document count in 'show collections' table. it tries to split count into groups of 3 e.g: 12,450 r(s) 

## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->
I've test it in my own server. The result is something like this:
se...       →     0.000MB /     0.004MB /          0 r(s)
shar...     →     0.049MB /     0.051MB /        279 r(s)
sh...       →     0.003MB /     0.016MB /         32 r(s)
sha...      →  3649.972MB /  1594.980MB /  1,250,528 r(s)
test...     → 27444.810MB / 12135.191MB / 75,349,867 r(s)
tr...       →   209.701MB /    92.375MB /    464,012 r(s)
tt...       →     0.003MB /     0.016MB /         32 r(s)
us...       →     0.000MB /     0.016MB /          1 r(s)

| Software         | Version(s) tested
| ---------------- | -----------------
| `mongo` shell    | 4.0.9
| MongoDB server   | 4.0.9
| Operating system | Linux Ubuntu 18.04.2 LTS
