### PR TITLE
Fix api methods that use _printExtraInfo

### DIFF
--- a/hacks/verbose.js
+++ b/hacks/verbose.js
@@ -3,7 +3,7 @@ setVerboseShell(mongo_hacker_config.verbose_shell);
 DBQuery.prototype._prettyShell = true
 
 // Display verbose information about the operation
-DBCollection.prototype._printExtraInfo = function(action, startTime) {
+DBQuery.prototype._printExtraInfo = function(action, startTime) {
     if (typeof _verboseShell === 'undefined' || !_verboseShell) {
         __callLastError = true;
         return;


### PR DESCRIPTION
Fix #216

## Testing
```
> db.test.insert({ a: 1})
Inserted 1 record(s) in 4ms
WriteResult({
  "nInserted": 1
})
> db.test.find({a:1}).remove()
Removed 1 document(s) in 2ms
```

| Software         | Version(s) tested
| ---------------- | -----------------
| `mongo` shell    | 0.1.1
| MongoDB server   | v4.4.10
| Operating system | macos
