### PR TITLE
Makes it obvious how to run mongo-hacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ```sh
 npm install -g mongo-hacker
+mongo
 ```
 
 
@@ -31,6 +32,7 @@ cd mongo-hacker
 make install
 cd ..
 rm -rdf mongo-hacker/
+mongo
 ```
 
 ## Enhancements


### PR DESCRIPTION
## Description of changes
Adds `mongo` to 2 places in the README

## Why
I haven't used mongo-hacker for a few years, so I forgot how to run it. For whatever reason I assumed that it runs as it's own shell app.
Reading the README, it wasn't obvious to me.
I spent about 15 mins trying to figure it out, going into ~/.nvm/versions/node/v17.2.0/lib/node_modules/mongo-hacker and trying to run the js files with node haha.
I thought maybe because it hasn't been updated since 2019 (around the time of Mongo 3.4 apparently, and now we're on Mongo 5) that it was probably old and broken.
I was getting print() not defined, and _isWindows not defined etc. i tried hacking the JS and adding in `const print = console.log;` and `const _isWindows = () => false;` etc hahaha
Then finally I checked the make file and noticed it updates .mongorc then I looked at .mongorc etc and realized it probably runs inside `mongo`

I think 2 lines would save many people the trouble of wondering how to run it.