### PR TITLE
Added minimal_quotes feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ mongo
   - Default indent is 2 spaces instead of tab (config: `indent`)
   - Disable notification of "Type 'it' for more"
   - Option to sort document keys (config: `sort_keys`)
+  - Option to format keys in JavaScript style (config: `javascript_keys`)
   - Custom prompt: `hostname(process-version)[rs_status:set_name] db>`
   - Always pretty print. You can still use default format by appending `.ugly()` to the end of a statement.
   - Colorized query output for console/terminal windows supporting ANSI color codes.
@@ -160,29 +161,29 @@ db.test.aggregate().group({_id: '$a', 'sum': {'$sum': 1}}).sort({sum: -1})
 
 #### Data Generation
 
-For easy and simple random data generation you can utilise these methods below. You can use any of these functions in a loop. For example: 
+For easy and simple random data generation you can utilise these methods below. You can use any of these functions in a loop. For example:
 
 ```js
-// Inserts 20 documents with random data. 
-for (i=1; i<21; i++) { 
+// Inserts 20 documents with random data.
+for (i=1; i<21; i++) {
     db.collection.insert(
             {
-             word: randomWord(), 
-             number: randomNumber(), 
-             date: randomDate() 
+             word: randomWord(),
+             number: randomNumber(),
+             date: randomDate()
             }
-    ); 
+    );
 }
 ```
 
-##### randomWord 
+##### randomWord
 
 You can specify the length of each word, the number of words, and an optional seeded word in a sentence randomly. Use the optional `seed` parameter for testing text search.
 
-`randomWord(length=5, words=1, seed=undefined)` 
+`randomWord(length=5, words=1, seed=undefined)`
 
 ```js
-// Inserts a random sentence consisting of 5 letters per word, 5 words in total, 
+// Inserts a random sentence consisting of 5 letters per word, 5 words in total,
 // with a probability to insert the word 'needle' in the sentence
 db.collection.insert( { words: randomWord(5, 5, 'needle') } )
 
@@ -197,15 +198,15 @@ You can specify maximum number to be randomly generated (exclusive)
 `randomNumber(max=100)`
 
 ```js
-// Inserts a random number in the range of 0 or 1. 
+// Inserts a random number in the range of 0 or 1.
 db.collection.insert( { number: randomNumber(2) } )
 
-// Inserts a random number in the range of 0 or 999. 
+// Inserts a random number in the range of 0 or 999.
 db.collection.insert( { number: randomNumber(1000) } )
 
 ```
 
-##### randomDate 
+##### randomDate
 
 You can specify start and end dates range to be randomly generated. (exclusive)
 
@@ -215,7 +216,7 @@ You can specify start and end dates range to be randomly generated. (exclusive)
 // Inserts a random date object in the range of 1st January 2016 to 1st February 2016
 db.collection.insert( { date: randomDate(ISODate("2016-01-01T00:00:00"), ISODate("2016-02-01T00:00:00")) })
 
-// If today is 19th May 2016 and you specify only the start of the day, 
+// If today is 19th May 2016 and you specify only the start of the day,
 // this will generate random date object between 00:00:00 to current time.  
 db.collection.insert( { date: randomDate(ISODate("2016-05-19T00:00:00")) })
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ mongo
   - Disable notification of "Type 'it' for more"
   - Option to sort document keys (config: `sort_keys`)
   - Option to format keys in JavaScript style (config: `javascript_keys`)
+  - Option to quote strings minimally (config: `minimal_quotes`)
   - Custom prompt: `hostname(process-version)[rs_status:set_name] db>`
   - Always pretty print. You can still use default format by appending `.ugly()` to the end of a statement.
   - Colorized query output for console/terminal windows supporting ANSI color codes.

--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ mongo_hacker_config = {
   enhance_api:    true,             // additonal api extensions
   indent:         2,                // number of spaces for indent
   sort_keys:      false,            // sort the keys in documents when displayed
+  javascript_keys:false,            // output is formatted with JavaScript style keys
   uuid_type:      'default',        // 'java', 'c#', 'python' or 'default'
   banner_message: 'Mongo-Hacker ',  // banner message
   version:        '0.1.1',          // current mongo-hacker version
@@ -53,4 +54,3 @@ mongo_hacker_config = {
 if (mongo_hacker_config['show_banner']) {
   print(mongo_hacker_config['banner_message'] + mongo_hacker_config['version']);
 }
-

--- a/config.js
+++ b/config.js
@@ -16,6 +16,7 @@ mongo_hacker_config = {
   indent:         2,                // number of spaces for indent
   sort_keys:      false,            // sort the keys in documents when displayed
   javascript_keys:false,            // output is formatted with JavaScript style keys
+  minimal_quotes: false,            // single quote strings that don't contain them
   uuid_type:      'default',        // 'java', 'c#', 'python' or 'default'
   banner_message: 'Mongo-Hacker ',  // banner message
   version:        '0.1.1',          // current mongo-hacker version

--- a/hacks/common.js
+++ b/hacks/common.js
@@ -295,10 +295,11 @@ tojson = function( x, indent , nolint, nocolor, sort_keys ) {
     var s;
     switch ( typeof x ) {
     case "string": {
-        s = "\"";
+        var quoteChar = mongo_hacker_config.minimal_quotes && (x.indexOf("'")===-1 || x.indexOf('"')>-1) ? "'" : '"';
+        s = quoteChar;
         for ( var i=0; i<x.length; i++ ){
             switch (x[i]){
-                case '"': s += '\\"'; break;
+                case quoteChar: s += '\\' + quoteChar; break;
                 case '\\': s += '\\\\'; break;
                 case '\b': s += '\\b'; break;
                 case '\f': s += '\\f'; break;
@@ -316,7 +317,7 @@ tojson = function( x, indent , nolint, nocolor, sort_keys ) {
                 }
             }
         }
-        s += "\"";
+        s += quoteChar;
         return colorize(s, mongo_hacker_config.colors.string, nocolor);
     }
     case "number":

--- a/hacks/common.js
+++ b/hacks/common.js
@@ -249,7 +249,8 @@ tojsonObject = function( x, indent, nolint, nocolor, sort_keys ) {
             continue;
 
         var color = mongo_hacker_config.colors.key;
-        s += indent + colorize("\"" + key + "\"", color, nocolor) + ": " + tojson( val, indent , nolint, nocolor, sortKeys );
+        var formattedKey = mongo_hacker_config.javascript_keys && key.match(/^[A-Za-z_][A-Za-z\d_]*$/) ? key : '"' + key + '"';
+        s += indent + colorize(formattedKey, color, nocolor) + ": " + tojson( val, indent , nolint, nocolor, sortKeys );
         if (num != total) {
             s += ",";
             num++;


### PR DESCRIPTION
## Description of changes
When enabled, we will quote strings as minimally as possible.
So when a string doesn't contain `'` then we quote with single quotes.
If it contains `'` but not `"` then we quote with double quotes.
If a string contains single and double quotes, we quote with single quotes.

## Testing
I ran `make install` and ran a few queries with some test data.

| Software         | Version(s) tested
| ---------------- | -----------------
| `mongo` shell    | 5.0.7
| MongoDB server   | 5.0.7
| Operating system | Linux x64 on modern kernel

## Screenshots
`javascript_keys:true, minimal_quotes:false`
![image](https://user-images.githubusercontent.com/28704571/163238825-97f56032-472a-4e79-ab20-a834c5aa7c95.png)
`javascript_keys:true, minimal_quotes:true`
![image](https://user-images.githubusercontent.com/28704571/163238965-44b70417-3a76-4640-9cad-7b43a0fe0513.png)
